### PR TITLE
Align resource schema validation with the API

### DIFF
--- a/docs/resources/action_configuration.md
+++ b/docs/resources/action_configuration.md
@@ -38,10 +38,10 @@ resource "authsignal_action_configuration" "terraform-provider-test" {
 
 ### Optional
 
-- `default_verification_method` (String) Ignore the user's preference and choose which authenticator the Pre-built UI will present by default. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `PUSH`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `REDROCK`, `IDVERSE`.
+- `default_verification_method` (String) Ignore the user's preference and choose which authenticator the Pre-built UI will present by default. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `DEVICE`, `PUSH`, `QR_CODE`, `IN_APP`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `PALM_BIOMETRICS_RR`, `IDVERSE`, `ONFIDO`, `APPLE_ID_TOKEN`, `GOOGLE_ID_TOKEN`, `WHATSAPP`, `DIGITAL_CREDENTIAL`, `OIDC_PROVIDER`.
 - `messaging_templates` (String) Optional messaging templates to be shown in Authsignal's pre-built UI.
 - `prompt_to_enroll_verification_methods` (List of String) If this is set then users will be prompted to add a passkey after a challenge is completed. Allowed values: `[PASSKEY]`.
-- `verification_methods` (List of String) A list of permitted authenticators that can be used if the result of the action is 'CHALLENGE'. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `PUSH`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `REDROCK`, `IDVERSE`.
+- `verification_methods` (List of String) A list of permitted authenticators that can be used if the result of the action is 'CHALLENGE'. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `DEVICE`, `PUSH`, `QR_CODE`, `IN_APP`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `PALM_BIOMETRICS_RR`, `IDVERSE`, `ONFIDO`, `APPLE_ID_TOKEN`, `GOOGLE_ID_TOKEN`, `WHATSAPP`, `DIGITAL_CREDENTIAL`, `OIDC_PROVIDER`.
 
 ### Read-Only
 

--- a/docs/resources/rule.md
+++ b/docs/resources/rule.md
@@ -59,10 +59,10 @@ resource "authsignal_rule" "test" {
 
 ### Optional
 
-- `default_verification_method` (String) Ignore the user's preference and choose which authenticator the Pre-built UI will present by default. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `PUSH`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `REDROCK`, `IDVERSE`.
+- `default_verification_method` (String) Ignore the user's preference and choose which authenticator the Pre-built UI will present by default. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `DEVICE`, `PUSH`, `QR_CODE`, `IN_APP`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `PALM_BIOMETRICS_RR`, `IDVERSE`, `ONFIDO`, `APPLE_ID_TOKEN`, `GOOGLE_ID_TOKEN`, `WHATSAPP`, `DIGITAL_CREDENTIAL`, `OIDC_PROVIDER`.
 - `description` (String) A description of the rule.
 - `prompt_to_enroll_verification_methods` (List of String) If this is set then users will be prompted to add a passkey after a challenge is completed. Allowed values: `[PASSKEY]`.
-- `verification_methods` (List of String) A list of permitted authenticators that can be used if the type of the rule is 'CHALLENGE'. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `PUSH`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `REDROCK`, `IDVERSE`.
+- `verification_methods` (List of String) A list of permitted authenticators that can be used if the type of the rule is 'CHALLENGE'. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `DEVICE`, `PUSH`, `QR_CODE`, `IN_APP`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `PALM_BIOMETRICS_RR`, `IDVERSE`, `ONFIDO`, `APPLE_ID_TOKEN`, `GOOGLE_ID_TOKEN`, `WHATSAPP`, `DIGITAL_CREDENTIAL`, `OIDC_PROVIDER`.
 
 ### Read-Only
 

--- a/docs/resources/theme.md
+++ b/docs/resources/theme.md
@@ -184,8 +184,8 @@ Optional:
 
 Optional:
 
-- `content_alignment` (String) Allowed values: `left`, `center`.
-- `logo_alignment` (String) Allowed values: `left`, `center`.
+- `content_alignment` (String) Allowed values: `left`, `center`, `right`.
+- `logo_alignment` (String) Allowed values: `left`, `center`, `right`.
 - `logo_height` (Number)
 - `logo_position` (String) Allowed values: `inside`, `outside`.
 - `padding` (Number)
@@ -254,8 +254,8 @@ Optional:
 
 Optional:
 
-- `content_alignment` (String) Allowed values: `left`, `center`.
-- `logo_alignment` (String) Allowed values: `left`, `center`.
+- `content_alignment` (String) Allowed values: `left`, `center`, `right`.
+- `logo_alignment` (String) Allowed values: `left`, `center`, `right`.
 - `logo_height` (Number)
 - `logo_position` (String) Allowed values: `inside`, `outside`.
 - `padding` (Number)

--- a/internal/provider/action_configuration_resource.go
+++ b/internal/provider/action_configuration_resource.go
@@ -80,10 +80,10 @@ func (r *actionConfigurationResource) Schema(_ context.Context, _ resource.Schem
 			},
 			"verification_methods": schema.ListAttribute{
 				ElementType: types.StringType,
-				Description: "A list of permitted authenticators that can be used if the result of the action is 'CHALLENGE'. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `PUSH`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `REDROCK`, `IDVERSE`.",
+				Description: "A list of permitted authenticators that can be used if the result of the action is 'CHALLENGE'. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `DEVICE`, `PUSH`, `QR_CODE`, `IN_APP`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `PALM_BIOMETRICS_RR`, `IDVERSE`, `ONFIDO`, `APPLE_ID_TOKEN`, `GOOGLE_ID_TOKEN`, `WHATSAPP`, `DIGITAL_CREDENTIAL`, `OIDC_PROVIDER`.",
 				Optional:    true,
 				Validators: []validator.List{
-					listvalidator.ValueStringsAre(stringvalidator.OneOf([]string{"SMS", "AUTHENTICATOR_APP", "EMAIL_MAGIC_LINK", "EMAIL_OTP", "PUSH", "SECURITY_KEY", "PASSKEY", "VERIFF", "IPROOV", "REDROCK", "IDVERSE"}...)),
+					listvalidator.ValueStringsAre(stringvalidator.OneOf(allowedVerificationMethods...)),
 				},
 			},
 			"prompt_to_enroll_verification_methods": schema.ListAttribute{
@@ -95,10 +95,10 @@ func (r *actionConfigurationResource) Schema(_ context.Context, _ resource.Schem
 				},
 			},
 			"default_verification_method": schema.StringAttribute{
-				Description: "Ignore the user's preference and choose which authenticator the Pre-built UI will present by default. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `PUSH`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `REDROCK`, `IDVERSE`.",
+				Description: "Ignore the user's preference and choose which authenticator the Pre-built UI will present by default. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `DEVICE`, `PUSH`, `QR_CODE`, `IN_APP`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `PALM_BIOMETRICS_RR`, `IDVERSE`, `ONFIDO`, `APPLE_ID_TOKEN`, `GOOGLE_ID_TOKEN`, `WHATSAPP`, `DIGITAL_CREDENTIAL`, `OIDC_PROVIDER`.",
 				Optional:    true,
 				Validators: []validator.String{
-					stringvalidator.OneOf([]string{"SMS", "AUTHENTICATOR_APP", "EMAIL_MAGIC_LINK", "EMAIL_OTP", "PUSH", "SECURITY_KEY", "PASSKEY", "VERIFF", "IPROOV", "REDROCK", "IDVERSE"}...),
+					stringvalidator.OneOf(allowedVerificationMethods...),
 				},
 			},
 		},

--- a/internal/provider/rule_resource.go
+++ b/internal/provider/rule_resource.go
@@ -90,10 +90,10 @@ func (d *ruleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			},
 			"verification_methods": schema.ListAttribute{
 				ElementType: types.StringType,
-				Description: "A list of permitted authenticators that can be used if the type of the rule is 'CHALLENGE'. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `PUSH`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `REDROCK`, `IDVERSE`.",
+				Description: "A list of permitted authenticators that can be used if the type of the rule is 'CHALLENGE'. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `DEVICE`, `PUSH`, `QR_CODE`, `IN_APP`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `PALM_BIOMETRICS_RR`, `IDVERSE`, `ONFIDO`, `APPLE_ID_TOKEN`, `GOOGLE_ID_TOKEN`, `WHATSAPP`, `DIGITAL_CREDENTIAL`, `OIDC_PROVIDER`.",
 				Optional:    true,
 				Validators: []validator.List{
-					listvalidator.ValueStringsAre(stringvalidator.OneOf([]string{"SMS", "AUTHENTICATOR_APP", "EMAIL_MAGIC_LINK", "EMAIL_OTP", "PUSH", "SECURITY_KEY", "PASSKEY", "VERIFF", "IPROOV", "REDROCK", "IDVERSE"}...)),
+					listvalidator.ValueStringsAre(stringvalidator.OneOf(allowedVerificationMethods...)),
 				},
 			},
 			"prompt_to_enroll_verification_methods": schema.ListAttribute{
@@ -105,10 +105,10 @@ func (d *ruleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				},
 			},
 			"default_verification_method": schema.StringAttribute{
-				Description: "Ignore the user's preference and choose which authenticator the Pre-built UI will present by default. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `PUSH`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `REDROCK`, `IDVERSE`.",
+				Description: "Ignore the user's preference and choose which authenticator the Pre-built UI will present by default. Allowed values: `SMS`, `AUTHENTICATOR_APP`, `EMAIL_MAGIC_LINK`, `EMAIL_OTP`, `DEVICE`, `PUSH`, `QR_CODE`, `IN_APP`, `SECURITY_KEY`, `PASSKEY`, `VERIFF`, `IPROOV`, `PALM_BIOMETRICS_RR`, `IDVERSE`, `ONFIDO`, `APPLE_ID_TOKEN`, `GOOGLE_ID_TOKEN`, `WHATSAPP`, `DIGITAL_CREDENTIAL`, `OIDC_PROVIDER`.",
 				Optional:    true,
 				Validators: []validator.String{
-					stringvalidator.OneOf([]string{"SMS", "AUTHENTICATOR_APP", "EMAIL_MAGIC_LINK", "EMAIL_OTP", "PUSH", "SECURITY_KEY", "PASSKEY", "VERIFF", "IPROOV", "REDROCK", "IDVERSE"}...),
+					stringvalidator.OneOf(allowedVerificationMethods...),
 				},
 			},
 			"conditions": schema.StringAttribute{

--- a/internal/provider/theme_resource.go
+++ b/internal/provider/theme_resource.go
@@ -82,20 +82,20 @@ func (r *themeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			"container": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"content_alignment": schema.StringAttribute{
-						Description: "Allowed values: `left`, `center`.",
+						Description: "Allowed values: `left`, `center`, `right`.",
 						Optional:    true,
 						Validators: []validator.String{
-							stringvalidator.OneOf([]string{"left", "center"}...),
+							stringvalidator.OneOf([]string{"left", "center", "right"}...),
 						},
 					},
 					"padding": schema.Int64Attribute{
 						Optional: true,
 					},
 					"logo_alignment": schema.StringAttribute{
-						Description: "Allowed values: `left`, `center`.",
+						Description: "Allowed values: `left`, `center`, `right`.",
 						Optional:    true,
 						Validators: []validator.String{
-							stringvalidator.OneOf([]string{"left", "center"}...),
+							stringvalidator.OneOf([]string{"left", "center", "right"}...),
 						},
 					},
 					"logo_position": schema.StringAttribute{
@@ -256,20 +256,20 @@ func (r *themeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 					"container": schema.SingleNestedAttribute{
 						Attributes: map[string]schema.Attribute{
 							"content_alignment": schema.StringAttribute{
-								Description: "Allowed values: `left`, `center`.",
+								Description: "Allowed values: `left`, `center`, `right`.",
 								Optional:    true,
 								Validators: []validator.String{
-									stringvalidator.OneOf([]string{"left", "center"}...),
+									stringvalidator.OneOf([]string{"left", "center", "right"}...),
 								},
 							},
 							"padding": schema.Int64Attribute{
 								Optional: true,
 							},
 							"logo_alignment": schema.StringAttribute{
-								Description: "Allowed values: `left`, `center`.",
+								Description: "Allowed values: `left`, `center`, `right`.",
 								Optional:    true,
 								Validators: []validator.String{
-									stringvalidator.OneOf([]string{"left", "center"}...),
+									stringvalidator.OneOf([]string{"left", "center", "right"}...),
 								},
 							},
 							"logo_position": schema.StringAttribute{

--- a/internal/provider/verification_methods.go
+++ b/internal/provider/verification_methods.go
@@ -1,0 +1,24 @@
+package provider
+
+var allowedVerificationMethods = []string{
+	"SMS",
+	"AUTHENTICATOR_APP",
+	"EMAIL_MAGIC_LINK",
+	"EMAIL_OTP",
+	"DEVICE",
+	"PUSH",
+	"QR_CODE",
+	"IN_APP",
+	"SECURITY_KEY",
+	"PASSKEY",
+	"VERIFF",
+	"IPROOV",
+	"PALM_BIOMETRICS_RR",
+	"IDVERSE",
+	"ONFIDO",
+	"APPLE_ID_TOKEN",
+	"GOOGLE_ID_TOKEN",
+	"WHATSAPP",
+	"DIGITAL_CREDENTIAL",
+	"OIDC_PROVIDER",
+}


### PR DESCRIPTION
## Summary

Aligns the provider's client-side schema validation with the values the Management API actually accepts, which had drifted out of sync.

- Adds a shared `allowedVerificationMethods` list and uses it in the **action configuration** and **rule** resources, so their `verification_methods` validation stays in sync from one source.
- Allows `right` for the **theme** `content_alignment` and `logo_alignment` values (both light and dark mode).
- Regenerates the docs to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
