### PR TITLE
Take font faces on the theme, and drop dark mode typography

### DIFF
--- a/docs/data-sources/theme.md
+++ b/docs/data-sources/theme.md
@@ -169,7 +169,6 @@ Read-Only:
 
 
 
-
 <a id="nestedatt--page_background"></a>
 ### Nested Schema for `page_background`
 
@@ -202,6 +201,7 @@ Read-Only:
 
 - `url` (String) The URL of a font file.
 - `weight` (String) The weight this file covers. Either a single value such as `400`, or an ascending range such as `100 900` for a variable font.
+
 
 
 <a id="nestedatt--typography--text"></a>

--- a/docs/data-sources/theme.md
+++ b/docs/data-sources/theme.md
@@ -32,7 +32,7 @@ data "authsignal_theme" "theme" {
 - `name` (String) The name of the tenant which is visible to users.
 - `page_background` (Attributes) (see [below for nested schema](#nestedatt--page_background))
 - `primary_color` (String) The primary color for the tenant.
-- `typography` (Attributes) (see [below for nested schema](#nestedatt--typography))
+- `typography` (Attributes) The fonts used in the pre-built UI. A typeface is shared by light and dark mode. (see [below for nested schema](#nestedatt--typography))
 - `watermark_url` (String) The URL of an image to be used as a watermark at the bottom of Authsignal's pre-built UI.
 
 <a id="nestedatt--borders"></a>
@@ -102,7 +102,6 @@ Read-Only:
 - `logo_url` (String) The URL of an image to be used as a logo for the tenant.
 - `page_background` (Attributes) (see [below for nested schema](#nestedatt--dark_mode--page_background))
 - `primary_color` (String) The primary color for the tenant.
-- `typography` (Attributes) (see [below for nested schema](#nestedatt--dark_mode--typography))
 - `watermark_url` (String) The URL of an image to be used as a watermark at the bottom of Authsignal's pre-built UI.
 
 <a id="nestedatt--dark_mode--borders"></a>
@@ -169,21 +168,6 @@ Read-Only:
 - `background_image_url` (String) The URL of an image which will be used as the background in the pre-built UI.
 
 
-<a id="nestedatt--dark_mode--typography"></a>
-### Nested Schema for `dark_mode.typography`
-
-Read-Only:
-
-- `display` (Attributes) (see [below for nested schema](#nestedatt--dark_mode--typography--display))
-
-<a id="nestedatt--dark_mode--typography--display"></a>
-### Nested Schema for `dark_mode.typography.display`
-
-Read-Only:
-
-- `font_url` (String) The URL of a font file to be used for the tenant.
-
-
 
 
 <a id="nestedatt--page_background"></a>
@@ -200,11 +184,38 @@ Read-Only:
 
 Read-Only:
 
-- `display` (Attributes) (see [below for nested schema](#nestedatt--typography--display))
+- `display` (Attributes) The typeface used for headings. (see [below for nested schema](#nestedatt--typography--display))
+- `text` (Attributes) The typeface used for body text and UI labels. (see [below for nested schema](#nestedatt--typography--text))
 
 <a id="nestedatt--typography--display"></a>
 ### Nested Schema for `typography.display`
 
 Read-Only:
 
-- `font_url` (String) The URL of a font file to be used for the tenant.
+- `faces` (Attributes List) The font files making up this typeface, one per weight. (see [below for nested schema](#nestedatt--typography--display--faces))
+- `font_url` (String, Deprecated) The URL of a single font file to be used for this typeface.
+
+<a id="nestedatt--typography--display--faces"></a>
+### Nested Schema for `typography.display.faces`
+
+Read-Only:
+
+- `url` (String) The URL of a font file.
+- `weight` (String) The weight this file covers. Either a single value such as `400`, or an ascending range such as `100 900` for a variable font.
+
+
+<a id="nestedatt--typography--text"></a>
+### Nested Schema for `typography.text`
+
+Read-Only:
+
+- `faces` (Attributes List) The font files making up this typeface, one per weight. (see [below for nested schema](#nestedatt--typography--text--faces))
+- `font_url` (String, Deprecated) The URL of a single font file to be used for this typeface.
+
+<a id="nestedatt--typography--text--faces"></a>
+### Nested Schema for `typography.text.faces`
+
+Read-Only:
+
+- `url` (String) The URL of a font file.
+- `weight` (String) The weight this file covers. Either a single value such as `400`, or an ascending range such as `100 900` for a variable font.

--- a/docs/guides/version-3-upgrade.md
+++ b/docs/guides/version-3-upgrade.md
@@ -1,0 +1,67 @@
+---
+page_title: "Upgrading to v3"
+subcategory: ""
+description: |-
+  Upgrading the Authsignal provider from v2 to v3.
+---
+
+# Upgrading to v3
+
+v3 changes how fonts are configured on `authsignal_theme`. Nothing else in the provider changes.
+
+## `dark_mode.typography` has been removed
+
+A typeface is now shared by both colour modes, so the Management API no longer accepts a per-mode
+typeface. Requests that send one are rejected, which means any `authsignal_theme` apply on v2 fails
+against the current API whether or not you set a dark mode font.
+
+Remove the block:
+
+```diff
+ resource "authsignal_theme" "theme" {
+   dark_mode = {
+-    typography = {
+-      display = {
+-        font_url = "https://cdn.example.com/display.woff2"
+-      }
+-    }
+     colors = {
+       body_text = "#ABCD12"
+     }
+   }
+ }
+```
+
+The top-level `typography` block applies to both light and dark mode. If you were relying on a
+dark-mode-only font, set it at the top level instead — there is no longer a way to vary the typeface
+by mode.
+
+## `typography` takes two roles and a list of faces
+
+`typography` now has a `text` role for body copy and UI labels, alongside the existing `display` role
+for headings. Each role takes a `faces` list of up to six font files, each with the weight it covers:
+
+```hcl
+resource "authsignal_theme" "theme" {
+  typography = {
+    text = {
+      faces = [
+        { url = "https://cdn.example.com/regular.woff2", weight = "400" },
+        { url = "https://cdn.example.com/bold.woff2", weight = "700" },
+      ]
+    }
+    display = {
+      faces = [
+        { url = "https://cdn.example.com/display-variable.woff2", weight = "100 900" },
+      ]
+    }
+  }
+}
+```
+
+A weight is a single value from 1 to 1000, or an ascending range such as `100 900` for a variable
+font. A descending range is rejected.
+
+`font_url` still works and is unchanged, so an existing `typography.display.font_url` needs no edit.
+It is deprecated in favour of `faces`, which lets you supply a weight per file rather than a single
+file for every weight.

--- a/docs/resources/theme.md
+++ b/docs/resources/theme.md
@@ -63,6 +63,19 @@ resource "authsignal_theme" "theme" {
     logo_position     = "inside"
     logo_height       = 2
   }
+  typography = {
+    text = {
+      faces = [
+        { url = "<url to a font file>", weight = "400" },
+        { url = "<url to a font file>", weight = "700" },
+      ]
+    }
+    display = {
+      faces = [
+        { url = "<url to a variable font file>", weight = "100 900" },
+      ]
+    }
+  }
   dark_mode = {
     logo_url      = "<url to an image>"
     favicon_url   = "<url to an image>"
@@ -133,7 +146,7 @@ resource "authsignal_theme" "theme" {
 - `logo_url` (String) The URL of an image to be used as a logo for the tenant.
 - `page_background` (Attributes) (see [below for nested schema](#nestedatt--page_background))
 - `primary_color` (String) The primary color for the tenant.
-- `typography` (Attributes) (see [below for nested schema](#nestedatt--typography))
+- `typography` (Attributes) The fonts used in the pre-built UI. A typeface is shared by light and dark mode. (see [below for nested schema](#nestedatt--typography))
 - `watermark_url` (String) The URL of an image to be used as a watermark at the bottom of Authsignal's pre-built UI.
 
 <a id="nestedatt--borders"></a>
@@ -203,7 +216,6 @@ Optional:
 - `logo_url` (String) The URL of an image to be used as a logo for the tenant.
 - `page_background` (Attributes) (see [below for nested schema](#nestedatt--dark_mode--page_background))
 - `primary_color` (String) The primary color for the tenant.
-- `typography` (Attributes) (see [below for nested schema](#nestedatt--dark_mode--typography))
 - `watermark_url` (String) The URL of an image to be used as a watermark at the bottom of Authsignal's pre-built UI.
 
 <a id="nestedatt--dark_mode--borders"></a>
@@ -270,21 +282,6 @@ Optional:
 - `background_image_url` (String) The URL of an image which will be used as the background in the pre-built UI.
 
 
-<a id="nestedatt--dark_mode--typography"></a>
-### Nested Schema for `dark_mode.typography`
-
-Optional:
-
-- `display` (Attributes) (see [below for nested schema](#nestedatt--dark_mode--typography--display))
-
-<a id="nestedatt--dark_mode--typography--display"></a>
-### Nested Schema for `dark_mode.typography.display`
-
-Optional:
-
-- `font_url` (String) The URL of a font file to be used for the tenant.
-
-
 
 
 <a id="nestedatt--page_background"></a>
@@ -301,15 +298,47 @@ Optional:
 
 Optional:
 
-- `display` (Attributes) (see [below for nested schema](#nestedatt--typography--display))
+- `display` (Attributes) The typeface used for headings. (see [below for nested schema](#nestedatt--typography--display))
+- `text` (Attributes) The typeface used for body text and UI labels. (see [below for nested schema](#nestedatt--typography--text))
 
 <a id="nestedatt--typography--display"></a>
 ### Nested Schema for `typography.display`
 
 Optional:
 
-- `font_url` (String) The URL of a font file to be used for the tenant.
+- `faces` (Attributes List) The font files making up this typeface, one per weight. At most 6. (see [below for nested schema](#nestedatt--typography--display--faces))
+- `font_url` (String, Deprecated) The URL of a single font file to be used for this typeface.
 
+<a id="nestedatt--typography--display--faces"></a>
+### Nested Schema for `typography.display.faces`
+
+Required:
+
+- `url` (String) The URL of a font file.
+
+Optional:
+
+- `weight` (String) The weight this file covers. Either a single value such as `400`, or an ascending range such as `100 900` for a variable font.
+
+
+<a id="nestedatt--typography--text"></a>
+### Nested Schema for `typography.text`
+
+Optional:
+
+- `faces` (Attributes List) The font files making up this typeface, one per weight. At most 6. (see [below for nested schema](#nestedatt--typography--text--faces))
+- `font_url` (String, Deprecated) The URL of a single font file to be used for this typeface.
+
+<a id="nestedatt--typography--text--faces"></a>
+### Nested Schema for `typography.text.faces`
+
+Required:
+
+- `url` (String) The URL of a font file.
+
+Optional:
+
+- `weight` (String) The weight this file covers. Either a single value such as `400`, or an ascending range such as `100 900` for a variable font.
 ## Import
 
 Import is supported using the following syntax:

--- a/docs/resources/theme.md
+++ b/docs/resources/theme.md
@@ -283,7 +283,6 @@ Optional:
 
 
 
-
 <a id="nestedatt--page_background"></a>
 ### Nested Schema for `page_background`
 
@@ -321,6 +320,7 @@ Optional:
 - `weight` (String) The weight this file covers. Either a single value such as `400`, or an ascending range such as `100 900` for a variable font.
 
 
+
 <a id="nestedatt--typography--text"></a>
 ### Nested Schema for `typography.text`
 
@@ -339,6 +339,7 @@ Required:
 Optional:
 
 - `weight` (String) The weight this file covers. Either a single value such as `400`, or an ascending range such as `100 900` for a variable font.
+
 ## Import
 
 Import is supported using the following syntax:

--- a/examples/resources/authsignal_theme/resource.tf
+++ b/examples/resources/authsignal_theme/resource.tf
@@ -48,6 +48,19 @@ resource "authsignal_theme" "theme" {
     logo_position     = "inside"
     logo_height       = 2
   }
+  typography = {
+    text = {
+      faces = [
+        { url = "<url to a font file>", weight = "400" },
+        { url = "<url to a font file>", weight = "700" },
+      ]
+    }
+    display = {
+      faces = [
+        { url = "<url to a variable font file>", weight = "100 900" },
+      ]
+    }
+  }
   dark_mode = {
     logo_url      = "<url to an image>"
     favicon_url   = "<url to an image>"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/authsignal/terraform-provider-authsignal
 go 1.25.0
 
 require (
-	github.com/authsignal/authsignal-management-go/v4 v4.2.0
+	github.com/authsignal/authsignal-management-go/v5 v5.0.0
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/authsignal/authsignal-management-go/v4 v4.2.0 h1:8AFwKq1Bcabl1nXSX2p1pFyfz9Ay/y31Lar6DEwKR3Y=
-github.com/authsignal/authsignal-management-go/v4 v4.2.0/go.mod h1:CfSWBfj5PC3HVagzfk5Vcjv6Hp8tRJJ8ERV6lVU4PJQ=
+github.com/authsignal/authsignal-management-go/v5 v5.0.0 h1:dj+3aZ2rRye1rTq3Vj351gX8f9FzZb0KF4iHJOWlZSk=
+github.com/authsignal/authsignal-management-go/v5 v5.0.0/go.mod h1:neKJskiUeYkSr/AK09K5/H77j0Z3cwSQQltrB1xXm3M=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=

--- a/internal/provider/action_configuration_data_source.go
+++ b/internal/provider/action_configuration_data_source.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/provider/action_configuration_resource.go
+++ b/internal/provider/action_configuration_resource.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"

--- a/internal/provider/custom_data_point_data_source.go
+++ b/internal/provider/custom_data_point_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/provider/custom_data_point_resource.go
+++ b/internal/provider/custom_data_point_resource.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/message_overrides_catalog_data_source.go
+++ b/internal/provider/message_overrides_catalog_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/provider/message_overrides_data_source.go
+++ b/internal/provider/message_overrides_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/provider/message_overrides_resource.go
+++ b/internal/provider/message_overrides_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"

--- a/internal/provider/rule_data_source.go
+++ b/internal/provider/rule_data_source.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/provider/rule_resource.go
+++ b/internal/provider/rule_resource.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"

--- a/internal/provider/theme_authsignal_objects.go
+++ b/internal/provider/theme_authsignal_objects.go
@@ -3,8 +3,10 @@ package provider
 import (
 	"context"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
@@ -103,26 +105,59 @@ func buildAuthsignalColorsCreateObject(colors colorsModel) authsignal.Colors {
 	return authsignalColors
 }
 
-func buildAuthsignalDisplayCreateObject(display displayModel) authsignal.Display {
-	var authsignalDisplay authsignal.Display
+func buildAuthsignalFontFaces(ctx context.Context, faces types.List) ([]authsignal.FontFace, diag.Diagnostics) {
+	var faceModels []fontFaceModel
 
-	if len(display.FontUrl.ValueString()) > 0 {
-		authsignalDisplay.FontUrl = authsignal.SetValue(display.FontUrl.ValueString())
+	diags := faces.ElementsAs(ctx, &faceModels, false)
+	if diags.HasError() {
+		return nil, diags
 	}
 
-	return authsignalDisplay
+	authsignalFaces := make([]authsignal.FontFace, 0, len(faceModels))
+
+	for _, face := range faceModels {
+		authsignalFaces = append(authsignalFaces, authsignal.FontFace{
+			Url:    face.Url.ValueString(),
+			Weight: authsignal.FontWeight(face.Weight.ValueString()),
+		})
+	}
+
+	return authsignalFaces, diags
+}
+
+func buildAuthsignalTypefaceCreateObject(ctx context.Context, resp *resource.CreateResponse, typeface typefaceModel) authsignal.Typeface {
+	var authsignalTypeface authsignal.Typeface
+
+	if !typeface.Faces.IsNull() {
+		faces, diags := buildAuthsignalFontFaces(ctx, typeface.Faces)
+		resp.Diagnostics.Append(diags...)
+		authsignalTypeface.Faces = authsignal.SetValue(faces)
+	}
+
+	if len(typeface.FontUrl.ValueString()) > 0 {
+		authsignalTypeface.FontUrl = authsignal.SetValue(typeface.FontUrl.ValueString())
+	}
+
+	return authsignalTypeface
 }
 
 func buildAuthsignalTypographyCreateObject(ctx context.Context, resp *resource.CreateResponse, typography typographyModel) authsignal.Typography {
 	var authsignalTypography authsignal.Typography
-	var displayValues displayModel
+	var textValues typefaceModel
+	var displayValues typefaceModel
+
+	if !typography.Text.IsNull() {
+		diags := typography.Text.As(ctx, &textValues, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(diags...)
+	}
 
 	if !typography.Display.IsNull() {
 		diags := typography.Display.As(ctx, &displayValues, basetypes.ObjectAsOptions{})
 		resp.Diagnostics.Append(diags...)
 	}
 
-	authsignalTypography.Display = authsignal.SetValue(buildAuthsignalDisplayCreateObject(displayValues))
+	authsignalTypography.Text = authsignal.SetValue(buildAuthsignalTypefaceCreateObject(ctx, resp, textValues))
+	authsignalTypography.Display = authsignal.SetValue(buildAuthsignalTypefaceCreateObject(ctx, resp, displayValues))
 
 	return authsignalTypography
 }
@@ -206,7 +241,6 @@ func buildAuthsignalThemeCreateObject(ctx context.Context, resp *resource.Create
 	var darkModeColorsValues colorsModel
 	var darkModeBordersValues bordersModel
 	var darkModeContainerValues containerModel
-	var darkModeTypographyValues typographyModel
 	var darkModePageBackgroundValues pageBackgroundModel
 
 	if !input.DarkMode.IsNull() {
@@ -230,11 +264,6 @@ func buildAuthsignalThemeCreateObject(ctx context.Context, resp *resource.Create
 
 		if !darkModeValues.PageBackground.IsNull() {
 			diags = darkModeValues.PageBackground.As(ctx, &darkModePageBackgroundValues, basetypes.ObjectAsOptions{})
-			resp.Diagnostics.Append(diags...)
-		}
-
-		if !darkModeValues.Typography.IsNull() {
-			diags = darkModeValues.Typography.As(ctx, &darkModeTypographyValues, basetypes.ObjectAsOptions{})
 			resp.Diagnostics.Append(diags...)
 		}
 	}
@@ -275,7 +304,6 @@ func buildAuthsignalThemeCreateObject(ctx context.Context, resp *resource.Create
 	authsignalDarkMode.Borders = authsignal.SetValue(buildAuthsignalBordersCreateObject(darkModeBordersValues))
 	authsignalDarkMode.Container = authsignal.SetValue(buildAuthsignalContainerCreateObject(darkModeContainerValues))
 	authsignalDarkMode.PageBackground = authsignal.SetValue(buildAuthsignalPageBackgroundCreateObject(darkModePageBackgroundValues))
-	authsignalDarkMode.Typography = authsignal.SetValue(buildAuthsignalTypographyCreateObject(ctx, resp, darkModeTypographyValues))
 
 	if len(darkModeValues.LogoUrl.ValueString()) > 0 {
 		authsignalDarkMode.LogoUrl = authsignal.SetValue(darkModeValues.LogoUrl.ValueString())
@@ -464,28 +492,43 @@ func buildAuthsignalColorsUpdateObject(colors colorsModel) authsignal.Colors {
 	return authsignalColors
 }
 
-func buildAuthsignalDisplayUpdateObject(display displayModel) authsignal.Display {
-	var authsignalDisplay authsignal.Display
+func buildAuthsignalTypefaceUpdateObject(ctx context.Context, resp *resource.UpdateResponse, typeface typefaceModel) authsignal.Typeface {
+	var authsignalTypeface authsignal.Typeface
 
-	if len(display.FontUrl.ValueString()) > 0 {
-		authsignalDisplay.FontUrl = authsignal.SetValue(display.FontUrl.ValueString())
+	if !typeface.Faces.IsNull() {
+		faces, diags := buildAuthsignalFontFaces(ctx, typeface.Faces)
+		resp.Diagnostics.Append(diags...)
+		authsignalTypeface.Faces = authsignal.SetValue(faces)
 	} else {
-		authsignalDisplay.FontUrl = authsignal.SetNull(display.FontUrl.ValueString())
+		authsignalTypeface.Faces = authsignal.SetNull([]authsignal.FontFace{})
 	}
 
-	return authsignalDisplay
+	if len(typeface.FontUrl.ValueString()) > 0 {
+		authsignalTypeface.FontUrl = authsignal.SetValue(typeface.FontUrl.ValueString())
+	} else {
+		authsignalTypeface.FontUrl = authsignal.SetNull(typeface.FontUrl.ValueString())
+	}
+
+	return authsignalTypeface
 }
 
 func buildAuthsignalTypographyUpdateObject(ctx context.Context, resp *resource.UpdateResponse, typography typographyModel) authsignal.Typography {
 	var authsignalTypography authsignal.Typography
-	var displayValues displayModel
+	var textValues typefaceModel
+	var displayValues typefaceModel
+
+	if !typography.Text.IsNull() {
+		diags := typography.Text.As(ctx, &textValues, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(diags...)
+	}
 
 	if !typography.Display.IsNull() {
 		diags := typography.Display.As(ctx, &displayValues, basetypes.ObjectAsOptions{})
 		resp.Diagnostics.Append(diags...)
 	}
 
-	authsignalTypography.Display = authsignal.SetValue(buildAuthsignalDisplayUpdateObject(displayValues))
+	authsignalTypography.Text = authsignal.SetValue(buildAuthsignalTypefaceUpdateObject(ctx, resp, textValues))
+	authsignalTypography.Display = authsignal.SetValue(buildAuthsignalTypefaceUpdateObject(ctx, resp, displayValues))
 
 	return authsignalTypography
 }
@@ -597,7 +640,6 @@ func buildAuthsignalThemeUpdateObject(ctx context.Context, resp *resource.Update
 	var darkModeColorsValues colorsModel
 	var darkModeBordersValues bordersModel
 	var darkModeContainerValues containerModel
-	var darkModeTypographyValues typographyModel
 	var darkModePageBackgroundValues pageBackgroundModel
 
 	if !input.DarkMode.IsNull() {
@@ -621,11 +663,6 @@ func buildAuthsignalThemeUpdateObject(ctx context.Context, resp *resource.Update
 
 		if !darkModeValues.PageBackground.IsNull() {
 			diags = darkModeValues.PageBackground.As(ctx, &darkModePageBackgroundValues, basetypes.ObjectAsOptions{})
-			resp.Diagnostics.Append(diags...)
-		}
-
-		if !darkModeValues.Typography.IsNull() {
-			diags = darkModeValues.Typography.As(ctx, &darkModeTypographyValues, basetypes.ObjectAsOptions{})
 			resp.Diagnostics.Append(diags...)
 		}
 	}
@@ -666,7 +703,6 @@ func buildAuthsignalThemeUpdateObject(ctx context.Context, resp *resource.Update
 	authsignalDarkMode.Borders = authsignal.SetValue(buildAuthsignalBordersUpdateObject(darkModeBordersValues))
 	authsignalDarkMode.Container = authsignal.SetValue(buildAuthsignalContainerUpdateObject(darkModeContainerValues))
 	authsignalDarkMode.PageBackground = authsignal.SetValue(buildAuthsignalPageBackgroundUpdateObject(darkModePageBackgroundValues))
-	authsignalDarkMode.Typography = authsignal.SetValue(buildAuthsignalTypographyUpdateObject(ctx, resp, darkModeTypographyValues))
 
 	if len(darkModeValues.LogoUrl.ValueString()) > 0 {
 		authsignalDarkMode.LogoUrl = authsignal.SetValue(darkModeValues.LogoUrl.ValueString())
@@ -764,19 +800,20 @@ func buildAuthsignalColorsDeleteObject(colors colorsModel) authsignal.Colors {
 	return authsignalColors
 }
 
-func buildAuthsignalDisplayDeleteObject(display displayModel) authsignal.Display {
-	var authsignalDisplay authsignal.Display
+func buildAuthsignalTypefaceDeleteObject() authsignal.Typeface {
+	var authsignalTypeface authsignal.Typeface
 
-	authsignalDisplay.FontUrl = authsignal.SetNull(display.FontUrl.ValueString())
+	authsignalTypeface.Faces = authsignal.SetNull([]authsignal.FontFace{})
+	authsignalTypeface.FontUrl = authsignal.SetNull("")
 
-	return authsignalDisplay
+	return authsignalTypeface
 }
 
 func buildAuthsignalTypographyDeleteObject() authsignal.Typography {
 	var authsignalTypography authsignal.Typography
-	var displayValues displayModel
 
-	authsignalTypography.Display = authsignal.SetValue(buildAuthsignalDisplayDeleteObject(displayValues))
+	authsignalTypography.Text = authsignal.SetValue(buildAuthsignalTypefaceDeleteObject())
+	authsignalTypography.Display = authsignal.SetValue(buildAuthsignalTypefaceDeleteObject())
 
 	return authsignalTypography
 }
@@ -833,7 +870,6 @@ func buildAuthsignalThemeDeleteObject(input themeModel) authsignal.Theme {
 	authsignalDarkMode.Borders = authsignal.SetValue(buildAuthsignalBordersDeleteObject(darkModeBordersValues))
 	authsignalDarkMode.Container = authsignal.SetValue(buildAuthsignalContainerDeleteObject(darkModeContainerValues))
 	authsignalDarkMode.PageBackground = authsignal.SetValue(buildAuthsignalPageBackgroundDeleteObject(darkModePageBackgroundValues))
-	authsignalDarkMode.Typography = authsignal.SetValue(buildAuthsignalTypographyDeleteObject())
 
 	authsignalDarkMode.LogoUrl = authsignal.SetNull(darkModeValues.LogoUrl.ValueString())
 	authsignalDarkMode.WatermarkUrl = authsignal.SetNull(darkModeValues.WatermarkUrl.ValueString())

--- a/internal/provider/theme_data_source.go
+++ b/internal/provider/theme_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -25,6 +25,32 @@ type themeDataSource struct {
 
 func (d *themeDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_theme"
+}
+
+func typefaceDataSourceAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"faces": schema.ListNestedAttribute{
+			Description: "The font files making up this typeface, one per weight.",
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"url": schema.StringAttribute{
+						Description: "The URL of a font file.",
+						Computed:    true,
+					},
+					"weight": schema.StringAttribute{
+						Description: "The weight this file covers. Either a single value such as `400`, or an ascending range such as `100 900` for a variable font.",
+						Computed:    true,
+					},
+				},
+			},
+			Computed: true,
+		},
+		"font_url": schema.StringAttribute{
+			Description:        "The URL of a single font file to be used for this typeface.",
+			DeprecationMessage: "Use `faces` instead, which carries a weight for each font file.",
+			Computed:           true,
+		},
+	}
 }
 
 func (d *themeDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -97,15 +123,17 @@ func (d *themeDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 				Computed: true,
 			},
 			"typography": schema.SingleNestedAttribute{
+				Description: "The fonts used in the pre-built UI. A typeface is shared by light and dark mode.",
 				Attributes: map[string]schema.Attribute{
+					"text": schema.SingleNestedAttribute{
+						Description: "The typeface used for body text and UI labels.",
+						Attributes:  typefaceDataSourceAttributes(),
+						Computed:    true,
+					},
 					"display": schema.SingleNestedAttribute{
-						Attributes: map[string]schema.Attribute{
-							"font_url": schema.StringAttribute{
-								Description: "The URL of a font file to be used for the tenant.",
-								Computed:    true,
-							},
-						},
-						Computed: true,
+						Description: "The typeface used for headings.",
+						Attributes:  typefaceDataSourceAttributes(),
+						Computed:    true,
 					},
 				},
 				Computed: true,
@@ -253,20 +281,6 @@ func (d *themeDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 								Computed: true,
 							},
 							"logo_height": schema.Int64Attribute{
-								Computed: true,
-							},
-						},
-						Computed: true,
-					},
-					"typography": schema.SingleNestedAttribute{
-						Attributes: map[string]schema.Attribute{
-							"display": schema.SingleNestedAttribute{
-								Attributes: map[string]schema.Attribute{
-									"font_url": schema.StringAttribute{
-										Description: "The URL of a font file to be used for the tenant.",
-										Computed:    true,
-									},
-								},
 								Computed: true,
 							},
 						},

--- a/internal/provider/theme_model.go
+++ b/internal/provider/theme_model.go
@@ -1,7 +1,7 @@
 package provider
 
 import (
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -108,6 +108,7 @@ func (m themeModel) AttributeValues() map[string]attr.Value {
 }
 
 // DARK MODE
+// A typeface is shared by both colour modes, so there is no dark mode typography.
 type darkModeModel struct {
 	LogoUrl        types.String `tfsdk:"logo_url"`
 	WatermarkUrl   types.String `tfsdk:"watermark_url"`
@@ -116,7 +117,6 @@ type darkModeModel struct {
 	Colors         types.Object `tfsdk:"colors"`
 	Container      types.Object `tfsdk:"container"`
 	Borders        types.Object `tfsdk:"borders"`
-	Typography     types.Object `tfsdk:"typography"`
 	PageBackground types.Object `tfsdk:"page_background"`
 }
 
@@ -169,12 +169,6 @@ func (m *darkModeModel) CreateObject(input authsignal.DarkModeResponse) types.Ob
 		isNull = 0
 	}
 
-	var typography typographyModel
-	m.Typography = typography.CreateObject(input.Typography)
-	if !m.Typography.IsNull() {
-		isNull = 0
-	}
-
 	var pageBackground pageBackgroundModel
 	m.PageBackground = pageBackground.CreateObject(input.PageBackground)
 	if !m.PageBackground.IsNull() {
@@ -198,7 +192,6 @@ func (m darkModeModel) AttributeTypes() map[string]attr.Type {
 		"colors":          types.ObjectType{AttrTypes: colorsModel{}.AttributeTypes()},
 		"container":       types.ObjectType{AttrTypes: containerModel{}.AttributeTypes()},
 		"borders":         types.ObjectType{AttrTypes: bordersModel{}.AttributeTypes()},
-		"typography":      types.ObjectType{AttrTypes: typographyModel{}.AttributeTypes()},
 		"page_background": types.ObjectType{AttrTypes: pageBackgroundModel{}.AttributeTypes()},
 	}
 }
@@ -212,7 +205,6 @@ func (m darkModeModel) AttributeValues() map[string]attr.Value {
 	elements["colors"] = m.Colors
 	elements["container"] = m.Container
 	elements["borders"] = m.Borders
-	elements["typography"] = m.Typography
 	elements["page_background"] = m.PageBackground
 
 	return elements
@@ -631,13 +623,65 @@ func (m bordersModel) AttributeValues() map[string]attr.Value {
 	return elements
 }
 
-// DISPLAY
-type displayModel struct {
+// FONT FACE
+type fontFaceModel struct {
+	Url    types.String `tfsdk:"url"`
+	Weight types.String `tfsdk:"weight"`
+}
+
+func (m *fontFaceModel) CreateObject(input authsignal.FontFaceResponse) types.Object {
+	m.Url = types.StringValue(input.Url)
+
+	if len(input.Weight) > 0 {
+		m.Weight = types.StringValue(string(input.Weight))
+	} else {
+		m.Weight = types.StringNull()
+	}
+
+	object, _ := types.ObjectValue(m.AttributeTypes(), m.AttributeValues())
+	return object
+}
+
+func (m fontFaceModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"url":    types.StringType,
+		"weight": types.StringType,
+	}
+}
+
+func (m fontFaceModel) AttributeValues() map[string]attr.Value {
+	elements := map[string]attr.Value{}
+	elements["url"] = m.Url
+	elements["weight"] = m.Weight
+	return elements
+}
+
+func fontFaceObjectType() types.ObjectType {
+	return types.ObjectType{AttrTypes: fontFaceModel{}.AttributeTypes()}
+}
+
+// TYPEFACE
+type typefaceModel struct {
+	Faces   types.List   `tfsdk:"faces"`
 	FontUrl types.String `tfsdk:"font_url"`
 }
 
-func (m *displayModel) CreateObject(input authsignal.DisplayResponse) types.Object {
+func (m *typefaceModel) CreateObject(input authsignal.TypefaceResponse) types.Object {
 	isNull := 1
+
+	if len(input.Faces) > 0 {
+		isNull = 0
+
+		faces := make([]attr.Value, 0, len(input.Faces))
+		for _, face := range input.Faces {
+			var fontFace fontFaceModel
+			faces = append(faces, fontFace.CreateObject(face))
+		}
+
+		m.Faces, _ = types.ListValue(fontFaceObjectType(), faces)
+	} else {
+		m.Faces = types.ListNull(fontFaceObjectType())
+	}
 
 	if len(input.FontUrl) > 0 {
 		isNull = 0
@@ -654,27 +698,36 @@ func (m *displayModel) CreateObject(input authsignal.DisplayResponse) types.Obje
 	return object
 }
 
-func (m displayModel) AttributeTypes() map[string]attr.Type {
+func (m typefaceModel) AttributeTypes() map[string]attr.Type {
 	return map[string]attr.Type{
+		"faces":    types.ListType{ElemType: fontFaceObjectType()},
 		"font_url": types.StringType,
 	}
 }
 
-func (m displayModel) AttributeValues() map[string]attr.Value {
+func (m typefaceModel) AttributeValues() map[string]attr.Value {
 	elements := map[string]attr.Value{}
+	elements["faces"] = m.Faces
 	elements["font_url"] = m.FontUrl
 	return elements
 }
 
 // TYPOGRAPHY
 type typographyModel struct {
+	Text    types.Object `tfsdk:"text"`
 	Display types.Object `tfsdk:"display"`
 }
 
 func (m *typographyModel) CreateObject(input authsignal.TypographyResponse) types.Object {
 	isNull := 1
 
-	var display displayModel
+	var text typefaceModel
+	m.Text = text.CreateObject(input.Text)
+	if !m.Text.IsNull() {
+		isNull = 0
+	}
+
+	var display typefaceModel
 	m.Display = display.CreateObject(input.Display)
 	if !m.Display.IsNull() {
 		isNull = 0
@@ -690,12 +743,14 @@ func (m *typographyModel) CreateObject(input authsignal.TypographyResponse) type
 
 func (m typographyModel) AttributeTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"display": types.ObjectType{AttrTypes: displayModel{}.AttributeTypes()},
+		"text":    types.ObjectType{AttrTypes: typefaceModel{}.AttributeTypes()},
+		"display": types.ObjectType{AttrTypes: typefaceModel{}.AttributeTypes()},
 	}
 }
 
 func (m typographyModel) AttributeValues() map[string]attr.Value {
 	elements := map[string]attr.Value{}
+	elements["text"] = m.Text
 	elements["display"] = m.Display
 	return elements
 }

--- a/internal/provider/theme_resource.go
+++ b/internal/provider/theme_resource.go
@@ -3,8 +3,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -17,6 +19,41 @@ var (
 	_ resource.ResourceWithConfigure   = &themeResource{}
 	_ resource.ResourceWithImportState = &themeResource{}
 )
+
+// Shape only. The API additionally rejects a range that does not ascend.
+var fontWeightPattern = regexp.MustCompile(`^(?:[1-9][0-9]{0,2}|1000)(?: (?:[1-9][0-9]{0,2}|1000))?$`)
+
+func typefaceResourceAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"faces": schema.ListNestedAttribute{
+			Description: fmt.Sprintf("The font files making up this typeface, one per weight. At most %d.", authsignal.MaxFontFacesPerTypeface),
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"url": schema.StringAttribute{
+						Description: "The URL of a font file.",
+						Required:    true,
+					},
+					"weight": schema.StringAttribute{
+						Description: "The weight this file covers. Either a single value such as `400`, or an ascending range such as `100 900` for a variable font.",
+						Optional:    true,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(fontWeightPattern, "must be a weight from 1 to 1000, such as `400`, or a range such as `100 900`"),
+						},
+					},
+				},
+			},
+			Optional: true,
+			Validators: []validator.List{
+				listvalidator.SizeAtMost(authsignal.MaxFontFacesPerTypeface),
+			},
+		},
+		"font_url": schema.StringAttribute{
+			Description:        "The URL of a single font file to be used for this typeface.",
+			DeprecationMessage: "Use `faces` instead, which carries a weight for each font file.",
+			Optional:           true,
+		},
+	}
+}
 
 func NewThemeResource() resource.Resource {
 	return &themeResource{}
@@ -112,15 +149,17 @@ func (r *themeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Optional: true,
 			},
 			"typography": schema.SingleNestedAttribute{
+				Description: "The fonts used in the pre-built UI. A typeface is shared by light and dark mode.",
 				Attributes: map[string]schema.Attribute{
+					"text": schema.SingleNestedAttribute{
+						Description: "The typeface used for body text and UI labels.",
+						Attributes:  typefaceResourceAttributes(),
+						Optional:    true,
+					},
 					"display": schema.SingleNestedAttribute{
-						Attributes: map[string]schema.Attribute{
-							"font_url": schema.StringAttribute{
-								Description: "The URL of a font file to be used for the tenant.",
-								Optional:    true,
-							},
-						},
-						Optional: true,
+						Description: "The typeface used for headings.",
+						Attributes:  typefaceResourceAttributes(),
+						Optional:    true,
 					},
 				},
 				Optional: true,
@@ -280,20 +319,6 @@ func (r *themeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 								},
 							},
 							"logo_height": schema.Int64Attribute{
-								Optional: true,
-							},
-						},
-						Optional: true,
-					},
-					"typography": schema.SingleNestedAttribute{
-						Attributes: map[string]schema.Attribute{
-							"display": schema.SingleNestedAttribute{
-								Attributes: map[string]schema.Attribute{
-									"font_url": schema.StringAttribute{
-										Description: "The URL of a font file to be used for the tenant.",
-										Optional:    true,
-									},
-								},
 								Optional: true,
 							},
 						},

--- a/internal/provider/value_list_data_source.go
+++ b/internal/provider/value_list_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"

--- a/internal/provider/value_list_resource.go
+++ b/internal/provider/value_list_resource.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/templates/guides/version-3-upgrade.md.tmpl
+++ b/templates/guides/version-3-upgrade.md.tmpl
@@ -1,0 +1,67 @@
+---
+page_title: "Upgrading to v3"
+subcategory: ""
+description: |-
+  Upgrading the Authsignal provider from v2 to v3.
+---
+
+# Upgrading to v3
+
+v3 changes how fonts are configured on `authsignal_theme`. Nothing else in the provider changes.
+
+## `dark_mode.typography` has been removed
+
+A typeface is now shared by both colour modes, so the Management API no longer accepts a per-mode
+typeface. Requests that send one are rejected, which means any `authsignal_theme` apply on v2 fails
+against the current API whether or not you set a dark mode font.
+
+Remove the block:
+
+```diff
+ resource "authsignal_theme" "theme" {
+   dark_mode = {
+-    typography = {
+-      display = {
+-        font_url = "https://cdn.example.com/display.woff2"
+-      }
+-    }
+     colors = {
+       body_text = "#ABCD12"
+     }
+   }
+ }
+```
+
+The top-level `typography` block applies to both light and dark mode. If you were relying on a
+dark-mode-only font, set it at the top level instead — there is no longer a way to vary the typeface
+by mode.
+
+## `typography` takes two roles and a list of faces
+
+`typography` now has a `text` role for body copy and UI labels, alongside the existing `display` role
+for headings. Each role takes a `faces` list of up to six font files, each with the weight it covers:
+
+```hcl
+resource "authsignal_theme" "theme" {
+  typography = {
+    text = {
+      faces = [
+        { url = "https://cdn.example.com/regular.woff2", weight = "400" },
+        { url = "https://cdn.example.com/bold.woff2", weight = "700" },
+      ]
+    }
+    display = {
+      faces = [
+        { url = "https://cdn.example.com/display-variable.woff2", weight = "100 900" },
+      ]
+    }
+  }
+}
+```
+
+A weight is a single value from 1 to 1000, or an ascending range such as `100 900` for a variable
+font. A descending range is rejected.
+
+`font_url` still works and is unchanged, so an existing `typography.display.font_url` needs no edit.
+It is deprecated in favour of `faces`, which lets you supply a weight per file rather than a single
+file for every weight.


### PR DESCRIPTION
## Problem

The Management API no longer accepts `darkMode.typography`, and the provider sent that key on every create and update whether or not a dark mode font was configured. Every `authsignal_theme` apply fails against the current API as a result.

The API also widened a typeface into a list of font files, each with the weight it covers, which the provider had no way to express.

## Approach

`dark_mode.typography` is removed rather than deprecated. A typeface now applies to both colour modes, so the attribute cannot be sent and reads back null — keeping it would let a config claim a font that no longer exists, and state would stop matching the remote object.

`typography` gains a `text` role for body copy alongside `display` for headings. Each role takes a `faces` list of up to six font files, one per weight:

```hcl
typography = {
  text = {
    faces = [
      { url = "https://cdn.example.com/regular.woff2", weight = "400" },
      { url = "https://cdn.example.com/bold.woff2", weight = "700" },
    ]
  }
  display = {
    faces = [
      { url = "https://cdn.example.com/display-variable.woff2", weight = "100 900" },
    ]
  }
}
```

A weight is a single value from 1 to 1000, or an ascending range for a variable font. `font_url` still works and is deprecated in favour of `faces`.

## Breaking change

This is `v3`, since removing an attribute breaks any config that sets it. `docs/guides/version-3-upgrade.md` covers the migration.

## Note on ordering

`go.mod` requires `authsignal-management-go` `v5.0.0`, which has to be tagged before this will build. CI here will fail until then.