### PR TITLE
Take the link underline and shadow switches on the theme

### DIFF
--- a/docs/data-sources/theme.md
+++ b/docs/data-sources/theme.md
@@ -28,10 +28,12 @@ data "authsignal_theme" "theme" {
 - `container` (Attributes) (see [below for nested schema](#nestedatt--container))
 - `dark_mode` (Attributes) (see [below for nested schema](#nestedatt--dark_mode))
 - `favicon_url` (String) The URL of an image to be used as a favicon for the tenant
+- `links` (Attributes) How links are drawn in the pre-built UI. Shared by light and dark mode. (see [below for nested schema](#nestedatt--links))
 - `logo_url` (String) The URL of an image to be used as a logo for the tenant.
 - `name` (String) The name of the tenant which is visible to users.
 - `page_background` (Attributes) (see [below for nested schema](#nestedatt--page_background))
 - `primary_color` (String) The primary color for the tenant.
+- `shadows` (Attributes) How shadows are drawn in the pre-built UI. Shared by light and dark mode. (see [below for nested schema](#nestedatt--shadows))
 - `typography` (Attributes) The fonts used in the pre-built UI. A typeface is shared by light and dark mode. (see [below for nested schema](#nestedatt--typography))
 - `watermark_url` (String) The URL of an image to be used as a watermark at the bottom of Authsignal's pre-built UI.
 
@@ -169,6 +171,14 @@ Read-Only:
 
 
 
+<a id="nestedatt--links"></a>
+### Nested Schema for `links`
+
+Read-Only:
+
+- `underline` (Boolean) Whether links are underlined.
+
+
 <a id="nestedatt--page_background"></a>
 ### Nested Schema for `page_background`
 
@@ -176,6 +186,14 @@ Read-Only:
 
 - `background_color` (String) The color to be used for the background in the pre-built UI.
 - `background_image_url` (String) The URL of an image which will be used as the background in the pre-built UI.
+
+
+<a id="nestedatt--shadows"></a>
+### Nested Schema for `shadows`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether elements such as cards and buttons cast a shadow.
 
 
 <a id="nestedatt--typography"></a>

--- a/docs/resources/theme.md
+++ b/docs/resources/theme.md
@@ -76,6 +76,12 @@ resource "authsignal_theme" "theme" {
       ]
     }
   }
+  links = {
+    underline = true
+  }
+  shadows = {
+    enabled = false
+  }
   dark_mode = {
     logo_url      = "<url to an image>"
     favicon_url   = "<url to an image>"
@@ -143,9 +149,11 @@ resource "authsignal_theme" "theme" {
 - `container` (Attributes) (see [below for nested schema](#nestedatt--container))
 - `dark_mode` (Attributes) (see [below for nested schema](#nestedatt--dark_mode))
 - `favicon_url` (String) The URL of an image to be used as a favicon for the tenant
+- `links` (Attributes) How links are drawn in the pre-built UI. Shared by light and dark mode. (see [below for nested schema](#nestedatt--links))
 - `logo_url` (String) The URL of an image to be used as a logo for the tenant.
 - `page_background` (Attributes) (see [below for nested schema](#nestedatt--page_background))
 - `primary_color` (String) The primary color for the tenant.
+- `shadows` (Attributes) How shadows are drawn in the pre-built UI. Shared by light and dark mode. (see [below for nested schema](#nestedatt--shadows))
 - `typography` (Attributes) The fonts used in the pre-built UI. A typeface is shared by light and dark mode. (see [below for nested schema](#nestedatt--typography))
 - `watermark_url` (String) The URL of an image to be used as a watermark at the bottom of Authsignal's pre-built UI.
 
@@ -283,6 +291,14 @@ Optional:
 
 
 
+<a id="nestedatt--links"></a>
+### Nested Schema for `links`
+
+Optional:
+
+- `underline` (Boolean) Whether links are underlined.
+
+
 <a id="nestedatt--page_background"></a>
 ### Nested Schema for `page_background`
 
@@ -290,6 +306,14 @@ Optional:
 
 - `background_color` (String) The color to be used for the background in the pre-built UI.
 - `background_image_url` (String) The URL of an image which will be used as the background in the pre-built UI.
+
+
+<a id="nestedatt--shadows"></a>
+### Nested Schema for `shadows`
+
+Optional:
+
+- `enabled` (Boolean) Whether elements such as cards and buttons cast a shadow.
 
 
 <a id="nestedatt--typography"></a>

--- a/examples/resources/authsignal_theme/resource.tf
+++ b/examples/resources/authsignal_theme/resource.tf
@@ -61,6 +61,12 @@ resource "authsignal_theme" "theme" {
       ]
     }
   }
+  links = {
+    underline = true
+  }
+  shadows = {
+    enabled = false
+  }
   dark_mode = {
     logo_url      = "<url to an image>"
     favicon_url   = "<url to an image>"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/authsignal/terraform-provider-authsignal
 go 1.25.0
 
 require (
-	github.com/authsignal/authsignal-management-go/v5 v5.0.0
+	github.com/authsignal/authsignal-management-go/v5 v5.1.0
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/authsignal/authsignal-management-go/v5 v5.0.0 h1:dj+3aZ2rRye1rTq3Vj351gX8f9FzZb0KF4iHJOWlZSk=
-github.com/authsignal/authsignal-management-go/v5 v5.0.0/go.mod h1:neKJskiUeYkSr/AK09K5/H77j0Z3cwSQQltrB1xXm3M=
+github.com/authsignal/authsignal-management-go/v5 v5.1.0 h1:4BNB3qwoB/tWhpmA3W+zK3wo2dUDEV8unuunZ/7KDxk=
+github.com/authsignal/authsignal-management-go/v5 v5.1.0/go.mod h1:neKJskiUeYkSr/AK09K5/H77j0Z3cwSQQltrB1xXm3M=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=

--- a/internal/provider/theme_authsignal_objects.go
+++ b/internal/provider/theme_authsignal_objects.go
@@ -162,6 +162,26 @@ func buildAuthsignalTypographyCreateObject(ctx context.Context, resp *resource.C
 	return authsignalTypography
 }
 
+func buildAuthsignalLinksCreateObject(links linksModel) authsignal.Links {
+	var authsignalLinks authsignal.Links
+
+	if !links.Underline.IsNull() {
+		authsignalLinks.Underline = authsignal.SetValue(links.Underline.ValueBool())
+	}
+
+	return authsignalLinks
+}
+
+func buildAuthsignalShadowsCreateObject(shadows shadowsModel) authsignal.Shadows {
+	var authsignalShadows authsignal.Shadows
+
+	if !shadows.Enabled.IsNull() {
+		authsignalShadows.Enabled = authsignal.SetValue(shadows.Enabled.ValueBool())
+	}
+
+	return authsignalShadows
+}
+
 func buildAuthsignalContainerCreateObject(container containerModel) authsignal.Container {
 	var authsignalContainer authsignal.Container
 
@@ -272,6 +292,8 @@ func buildAuthsignalThemeCreateObject(ctx context.Context, resp *resource.Create
 	var bordersValues bordersModel
 	var containerValues containerModel
 	var typographyValues typographyModel
+	var linksValues linksModel
+	var shadowsValues shadowsModel
 	var pageBackgroundValues pageBackgroundModel
 
 	if !input.Colors.IsNull() {
@@ -291,6 +313,16 @@ func buildAuthsignalThemeCreateObject(ctx context.Context, resp *resource.Create
 
 	if !input.Typography.IsNull() {
 		diags := input.Typography.As(ctx, &typographyValues, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(diags...)
+	}
+
+	if !input.Links.IsNull() {
+		diags := input.Links.As(ctx, &linksValues, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(diags...)
+	}
+
+	if !input.Shadows.IsNull() {
+		diags := input.Shadows.As(ctx, &shadowsValues, basetypes.ObjectAsOptions{})
 		resp.Diagnostics.Append(diags...)
 	}
 
@@ -328,6 +360,8 @@ func buildAuthsignalThemeCreateObject(ctx context.Context, resp *resource.Create
 	authsignalTheme.Container = authsignal.SetValue(buildAuthsignalContainerCreateObject(containerValues))
 	authsignalTheme.PageBackground = authsignal.SetValue(buildAuthsignalPageBackgroundCreateObject(pageBackgroundValues))
 	authsignalTheme.Typography = authsignal.SetValue(buildAuthsignalTypographyCreateObject(ctx, resp, typographyValues))
+	authsignalTheme.Links = authsignal.SetValue(buildAuthsignalLinksCreateObject(linksValues))
+	authsignalTheme.Shadows = authsignal.SetValue(buildAuthsignalShadowsCreateObject(shadowsValues))
 	authsignalTheme.DarkMode = authsignal.SetValue(authsignalDarkMode)
 
 	if len(input.Name.ValueString()) > 0 {
@@ -533,6 +567,30 @@ func buildAuthsignalTypographyUpdateObject(ctx context.Context, resp *resource.U
 	return authsignalTypography
 }
 
+func buildAuthsignalLinksUpdateObject(links linksModel) authsignal.Links {
+	var authsignalLinks authsignal.Links
+
+	if !links.Underline.IsNull() {
+		authsignalLinks.Underline = authsignal.SetValue(links.Underline.ValueBool())
+	} else {
+		authsignalLinks.Underline = authsignal.SetNull(false)
+	}
+
+	return authsignalLinks
+}
+
+func buildAuthsignalShadowsUpdateObject(shadows shadowsModel) authsignal.Shadows {
+	var authsignalShadows authsignal.Shadows
+
+	if !shadows.Enabled.IsNull() {
+		authsignalShadows.Enabled = authsignal.SetValue(shadows.Enabled.ValueBool())
+	} else {
+		authsignalShadows.Enabled = authsignal.SetNull(false)
+	}
+
+	return authsignalShadows
+}
+
 func buildAuthsignalContainerUpdateObject(container containerModel) authsignal.Container {
 	var authsignalContainer authsignal.Container
 
@@ -671,6 +729,8 @@ func buildAuthsignalThemeUpdateObject(ctx context.Context, resp *resource.Update
 	var bordersValues bordersModel
 	var containerValues containerModel
 	var typographyValues typographyModel
+	var linksValues linksModel
+	var shadowsValues shadowsModel
 	var pageBackgroundValues pageBackgroundModel
 
 	if !input.Colors.IsNull() {
@@ -690,6 +750,16 @@ func buildAuthsignalThemeUpdateObject(ctx context.Context, resp *resource.Update
 
 	if !input.Typography.IsNull() {
 		diags := input.Typography.As(ctx, &typographyValues, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(diags...)
+	}
+
+	if !input.Links.IsNull() {
+		diags := input.Links.As(ctx, &linksValues, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(diags...)
+	}
+
+	if !input.Shadows.IsNull() {
+		diags := input.Shadows.As(ctx, &shadowsValues, basetypes.ObjectAsOptions{})
 		resp.Diagnostics.Append(diags...)
 	}
 
@@ -735,6 +805,8 @@ func buildAuthsignalThemeUpdateObject(ctx context.Context, resp *resource.Update
 	authsignalTheme.Container = authsignal.SetValue(buildAuthsignalContainerUpdateObject(containerValues))
 	authsignalTheme.PageBackground = authsignal.SetValue(buildAuthsignalPageBackgroundUpdateObject(pageBackgroundValues))
 	authsignalTheme.Typography = authsignal.SetValue(buildAuthsignalTypographyUpdateObject(ctx, resp, typographyValues))
+	authsignalTheme.Links = authsignal.SetValue(buildAuthsignalLinksUpdateObject(linksValues))
+	authsignalTheme.Shadows = authsignal.SetValue(buildAuthsignalShadowsUpdateObject(shadowsValues))
 	authsignalTheme.DarkMode = authsignal.SetValue(authsignalDarkMode)
 
 	if len(input.Name.ValueString()) > 0 {
@@ -818,6 +890,22 @@ func buildAuthsignalTypographyDeleteObject() authsignal.Typography {
 	return authsignalTypography
 }
 
+func buildAuthsignalLinksDeleteObject() authsignal.Links {
+	var authsignalLinks authsignal.Links
+
+	authsignalLinks.Underline = authsignal.SetNull(false)
+
+	return authsignalLinks
+}
+
+func buildAuthsignalShadowsDeleteObject() authsignal.Shadows {
+	var authsignalShadows authsignal.Shadows
+
+	authsignalShadows.Enabled = authsignal.SetNull(false)
+
+	return authsignalShadows
+}
+
 func buildAuthsignalContainerDeleteObject(container containerModel) authsignal.Container {
 	var authsignalContainer authsignal.Container
 
@@ -883,6 +971,8 @@ func buildAuthsignalThemeDeleteObject(input themeModel) authsignal.Theme {
 	authsignalTheme.Container = authsignal.SetValue(buildAuthsignalContainerDeleteObject(containerValues))
 	authsignalTheme.PageBackground = authsignal.SetValue(buildAuthsignalPageBackgroundDeleteObject(pageBackgroundValues))
 	authsignalTheme.Typography = authsignal.SetValue(buildAuthsignalTypographyDeleteObject())
+	authsignalTheme.Links = authsignal.SetValue(buildAuthsignalLinksDeleteObject())
+	authsignalTheme.Shadows = authsignal.SetValue(buildAuthsignalShadowsDeleteObject())
 	authsignalTheme.DarkMode = authsignal.SetValue(authsignalDarkMode)
 
 	authsignalTheme.LogoUrl = authsignal.SetNull(input.LogoUrl.ValueString())

--- a/internal/provider/theme_data_source.go
+++ b/internal/provider/theme_data_source.go
@@ -138,6 +138,26 @@ func (d *themeDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 				},
 				Computed: true,
 			},
+			"links": schema.SingleNestedAttribute{
+				Description: "How links are drawn in the pre-built UI. Shared by light and dark mode.",
+				Attributes: map[string]schema.Attribute{
+					"underline": schema.BoolAttribute{
+						Description: "Whether links are underlined.",
+						Computed:    true,
+					},
+				},
+				Computed: true,
+			},
+			"shadows": schema.SingleNestedAttribute{
+				Description: "How shadows are drawn in the pre-built UI. Shared by light and dark mode.",
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Description: "Whether elements such as cards and buttons cast a shadow.",
+						Computed:    true,
+					},
+				},
+				Computed: true,
+			},
 			"page_background": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"background_color": schema.StringAttribute{

--- a/internal/provider/theme_model.go
+++ b/internal/provider/theme_model.go
@@ -18,6 +18,8 @@ type themeModel struct {
 	Container      types.Object `tfsdk:"container"`
 	Borders        types.Object `tfsdk:"borders"`
 	Typography     types.Object `tfsdk:"typography"`
+	Links          types.Object `tfsdk:"links"`
+	Shadows        types.Object `tfsdk:"shadows"`
 	PageBackground types.Object `tfsdk:"page_background"`
 }
 
@@ -64,6 +66,12 @@ func (m *themeModel) CreateObject(input authsignal.ThemeResponse) types.Object {
 	var typography typographyModel
 	m.Typography = typography.CreateObject(input.Typography)
 
+	var links linksModel
+	m.Links = links.CreateObject(input.Links)
+
+	var shadows shadowsModel
+	m.Shadows = shadows.CreateObject(input.Shadows)
+
 	var pageBackground pageBackgroundModel
 	m.PageBackground = pageBackground.CreateObject(input.PageBackground)
 
@@ -86,6 +94,8 @@ func (m themeModel) AttributeTypes() map[string]attr.Type {
 		"container":       types.ObjectType{AttrTypes: containerModel{}.AttributeTypes()},
 		"borders":         types.ObjectType{AttrTypes: bordersModel{}.AttributeTypes()},
 		"typography":      types.ObjectType{AttrTypes: typographyModel{}.AttributeTypes()},
+		"links":           types.ObjectType{AttrTypes: linksModel{}.AttributeTypes()},
+		"shadows":         types.ObjectType{AttrTypes: shadowsModel{}.AttributeTypes()},
 		"page_background": types.ObjectType{AttrTypes: pageBackgroundModel{}.AttributeTypes()},
 	}
 }
@@ -101,6 +111,8 @@ func (m themeModel) AttributeValues() map[string]attr.Value {
 	elements["container"] = m.Container
 	elements["borders"] = m.Borders
 	elements["typography"] = m.Typography
+	elements["links"] = m.Links
+	elements["shadows"] = m.Shadows
 	elements["page_background"] = m.PageBackground
 	elements["dark_mode"] = m.DarkMode
 
@@ -752,6 +764,65 @@ func (m typographyModel) AttributeValues() map[string]attr.Value {
 	elements := map[string]attr.Value{}
 	elements["text"] = m.Text
 	elements["display"] = m.Display
+	return elements
+}
+
+// LINKS
+type linksModel struct {
+	Underline types.Bool `tfsdk:"underline"`
+}
+
+// Unlike the rest of the theme, `false` is a value rather than emptiness. Only nil means unset.
+func (m *linksModel) CreateObject(input authsignal.LinksResponse) types.Object {
+	if input.Underline == nil {
+		m.Underline = types.BoolNull()
+		return types.ObjectNull(m.AttributeTypes())
+	}
+
+	m.Underline = types.BoolValue(*input.Underline)
+
+	object, _ := types.ObjectValue(m.AttributeTypes(), m.AttributeValues())
+	return object
+}
+
+func (m linksModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"underline": types.BoolType,
+	}
+}
+
+func (m linksModel) AttributeValues() map[string]attr.Value {
+	elements := map[string]attr.Value{}
+	elements["underline"] = m.Underline
+	return elements
+}
+
+// SHADOWS
+type shadowsModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}
+
+func (m *shadowsModel) CreateObject(input authsignal.ShadowsResponse) types.Object {
+	if input.Enabled == nil {
+		m.Enabled = types.BoolNull()
+		return types.ObjectNull(m.AttributeTypes())
+	}
+
+	m.Enabled = types.BoolValue(*input.Enabled)
+
+	object, _ := types.ObjectValue(m.AttributeTypes(), m.AttributeValues())
+	return object
+}
+
+func (m shadowsModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"enabled": types.BoolType,
+	}
+}
+
+func (m shadowsModel) AttributeValues() map[string]attr.Value {
+	elements := map[string]attr.Value{}
+	elements["enabled"] = m.Enabled
 	return elements
 }
 

--- a/internal/provider/theme_resource.go
+++ b/internal/provider/theme_resource.go
@@ -164,6 +164,26 @@ func (r *themeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				},
 				Optional: true,
 			},
+			"links": schema.SingleNestedAttribute{
+				Description: "How links are drawn in the pre-built UI. Shared by light and dark mode.",
+				Attributes: map[string]schema.Attribute{
+					"underline": schema.BoolAttribute{
+						Description: "Whether links are underlined.",
+						Optional:    true,
+					},
+				},
+				Optional: true,
+			},
+			"shadows": schema.SingleNestedAttribute{
+				Description: "How shadows are drawn in the pre-built UI. Shared by light and dark mode.",
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Description: "Whether elements such as cards and buttons cast a shadow.",
+						Optional:    true,
+					},
+				},
+				Optional: true,
+			},
 			"page_background": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"background_color": schema.StringAttribute{

--- a/internal/provider/theme_switches_test.go
+++ b/internal/provider/theme_switches_test.go
@@ -1,0 +1,90 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestSwitchesReadFalseAsAValueRatherThanAsAbsence(t *testing.T) {
+	off := false
+	on := true
+
+	testCases := []struct {
+		name          string
+		response      authsignal.LinksResponse
+		expectedNull  bool
+		expectedValue bool
+	}{
+		{name: "never set", response: authsignal.LinksResponse{}, expectedNull: true},
+		{name: "off", response: authsignal.LinksResponse{Underline: &off}, expectedValue: false},
+		{name: "on", response: authsignal.LinksResponse{Underline: &on}, expectedValue: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var links linksModel
+			object := links.CreateObject(testCase.response)
+
+			if object.IsNull() != testCase.expectedNull {
+				t.Fatalf("bad links object. expected null: %v. got null : %v", testCase.expectedNull, object.IsNull())
+			}
+
+			if testCase.expectedNull {
+				return
+			}
+
+			if links.Underline.ValueBool() != testCase.expectedValue {
+				t.Fatalf("bad underline. expected: %v. got : %v", testCase.expectedValue, links.Underline.ValueBool())
+			}
+		})
+	}
+}
+
+func TestSwitchesSendFalseRatherThanClearingIt(t *testing.T) {
+	testCases := []struct {
+		name         string
+		underline    types.Bool
+		enabled      types.Bool
+		expectedJson string
+	}{
+		{
+			name:         "unconfigured",
+			underline:    types.BoolNull(),
+			enabled:      types.BoolNull(),
+			expectedJson: "{\"links\":{\"underline\":null},\"shadows\":{\"enabled\":null}}",
+		},
+		{
+			name:         "off",
+			underline:    types.BoolValue(false),
+			enabled:      types.BoolValue(false),
+			expectedJson: "{\"links\":{\"underline\":false},\"shadows\":{\"enabled\":false}}",
+		},
+		{
+			name:         "on",
+			underline:    types.BoolValue(true),
+			enabled:      types.BoolValue(true),
+			expectedJson: "{\"links\":{\"underline\":true},\"shadows\":{\"enabled\":true}}",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			theme := authsignal.Theme{
+				Links:   authsignal.SetValue(buildAuthsignalLinksUpdateObject(linksModel{Underline: testCase.underline})),
+				Shadows: authsignal.SetValue(buildAuthsignalShadowsUpdateObject(shadowsModel{Enabled: testCase.enabled})),
+			}
+
+			jsonBody, err := json.Marshal(theme)
+			if err != nil {
+				t.Fatalf("failed to marshal json: %v", err)
+			}
+
+			if string(jsonBody) != testCase.expectedJson {
+				t.Fatalf("bad json. expected: %v. got : %v", testCase.expectedJson, string(jsonBody))
+			}
+		})
+	}
+}


### PR DESCRIPTION
`links.underline` and `shadows.enabled` are optional booleans on the theme, beside `typography`. Neither is a design token, so neither appears under `dark_mode` — both apply to light and dark mode alike.

A switch is read and written by nullness rather than by zero value, which is what the rest of the theme uses. `false` is what turns a switch off, so a zero value check would silently drop it, and the response would then read the cleared switch back as unset — leaving a permanent diff.

Requires authsignal-management-go v5.1.0, which is tagged and resolved.