### PR TITLE
Take an exit position on the theme container

### DIFF
--- a/docs/data-sources/theme.md
+++ b/docs/data-sources/theme.md
@@ -86,6 +86,7 @@ Read-Only:
 Read-Only:
 
 - `content_alignment` (String)
+- `exit_position` (String) Where the exit control sits: in the header band, or below the content. Shared by light and dark mode.
 - `logo_alignment` (String)
 - `logo_height` (Number)
 - `logo_position` (String)

--- a/docs/resources/theme.md
+++ b/docs/resources/theme.md
@@ -62,6 +62,7 @@ resource "authsignal_theme" "theme" {
     logo_alignment    = "center"
     logo_position     = "inside"
     logo_height       = 2
+    exit_position     = "bottom"
   }
   typography = {
     text = {
@@ -206,6 +207,7 @@ Optional:
 Optional:
 
 - `content_alignment` (String) Allowed values: `left`, `center`, `right`.
+- `exit_position` (String) Where the exit control sits: in the header band, or below the content. Shared by light and dark mode. Leaving it out keeps whatever the theme editor set, so clear it there rather than here. Allowed values: `top`, `bottom`.
 - `logo_alignment` (String) Allowed values: `left`, `center`, `right`.
 - `logo_height` (Number)
 - `logo_position` (String) Allowed values: `inside`, `outside`.

--- a/examples/resources/authsignal_theme/resource.tf
+++ b/examples/resources/authsignal_theme/resource.tf
@@ -47,6 +47,7 @@ resource "authsignal_theme" "theme" {
     logo_alignment    = "center"
     logo_position     = "inside"
     logo_height       = 2
+    exit_position     = "bottom"
   }
   typography = {
     text = {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/authsignal/terraform-provider-authsignal
 go 1.25.0
 
 require (
-	github.com/authsignal/authsignal-management-go/v5 v5.1.0
+	github.com/authsignal/authsignal-management-go/v6 v6.0.0
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/authsignal/authsignal-management-go/v5 v5.1.0 h1:4BNB3qwoB/tWhpmA3W+zK3wo2dUDEV8unuunZ/7KDxk=
-github.com/authsignal/authsignal-management-go/v5 v5.1.0/go.mod h1:neKJskiUeYkSr/AK09K5/H77j0Z3cwSQQltrB1xXm3M=
+github.com/authsignal/authsignal-management-go/v6 v6.0.0 h1:8BBgj1nJCHj/IRJBlhZYJVc6nRf7y2oHglQ1fm6plBE=
+github.com/authsignal/authsignal-management-go/v6 v6.0.0/go.mod h1:luvSna+OTu1QVlF4OOBl+sxA7Upr5P+/BNF4gy5GFnk=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=

--- a/internal/provider/action_configuration_data_source.go
+++ b/internal/provider/action_configuration_data_source.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/provider/action_configuration_resource.go
+++ b/internal/provider/action_configuration_resource.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"

--- a/internal/provider/custom_data_point_data_source.go
+++ b/internal/provider/custom_data_point_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/provider/custom_data_point_resource.go
+++ b/internal/provider/custom_data_point_resource.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/message_overrides_catalog_data_source.go
+++ b/internal/provider/message_overrides_catalog_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/provider/message_overrides_data_source.go
+++ b/internal/provider/message_overrides_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/provider/message_overrides_resource.go
+++ b/internal/provider/message_overrides_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"

--- a/internal/provider/rule_data_source.go
+++ b/internal/provider/rule_data_source.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/provider/rule_resource.go
+++ b/internal/provider/rule_resource.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"

--- a/internal/provider/theme_authsignal_objects.go
+++ b/internal/provider/theme_authsignal_objects.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -205,6 +205,36 @@ func buildAuthsignalContainerCreateObject(container containerModel) authsignal.C
 		authsignalContainer.LogoHeight = authsignal.SetValue(container.LogoHeight.ValueInt64())
 	}
 
+	if len(container.ExitPosition.ValueString()) > 0 {
+		authsignalContainer.ExitPosition = authsignal.SetValue(container.ExitPosition.ValueString())
+	}
+
+	return authsignalContainer
+}
+
+func buildAuthsignalModeContainerCreateObject(container modeContainerModel) authsignal.ModeContainer {
+	var authsignalContainer authsignal.ModeContainer
+
+	if len(container.ContentAlignment.ValueString()) > 0 {
+		authsignalContainer.ContentAlignment = authsignal.SetValue(container.ContentAlignment.ValueString())
+	}
+
+	if container.Padding.ValueInt64() != 0 {
+		authsignalContainer.Padding = authsignal.SetValue(container.Padding.ValueInt64())
+	}
+
+	if len(container.LogoAlignment.ValueString()) > 0 {
+		authsignalContainer.LogoAlignment = authsignal.SetValue(container.LogoAlignment.ValueString())
+	}
+
+	if len(container.LogoPosition.ValueString()) > 0 {
+		authsignalContainer.LogoPosition = authsignal.SetValue(container.LogoPosition.ValueString())
+	}
+
+	if container.LogoHeight.ValueInt64() != 0 {
+		authsignalContainer.LogoHeight = authsignal.SetValue(container.LogoHeight.ValueInt64())
+	}
+
 	return authsignalContainer
 }
 
@@ -260,7 +290,7 @@ func buildAuthsignalThemeCreateObject(ctx context.Context, resp *resource.Create
 	var darkModeValues darkModeModel
 	var darkModeColorsValues colorsModel
 	var darkModeBordersValues bordersModel
-	var darkModeContainerValues containerModel
+	var darkModeContainerValues modeContainerModel
 	var darkModePageBackgroundValues pageBackgroundModel
 
 	if !input.DarkMode.IsNull() {
@@ -334,7 +364,7 @@ func buildAuthsignalThemeCreateObject(ctx context.Context, resp *resource.Create
 	var authsignalDarkMode authsignal.DarkMode
 	authsignalDarkMode.Colors = authsignal.SetValue(buildAuthsignalColorsCreateObject(darkModeColorsValues))
 	authsignalDarkMode.Borders = authsignal.SetValue(buildAuthsignalBordersCreateObject(darkModeBordersValues))
-	authsignalDarkMode.Container = authsignal.SetValue(buildAuthsignalContainerCreateObject(darkModeContainerValues))
+	authsignalDarkMode.Container = authsignal.SetValue(buildAuthsignalModeContainerCreateObject(darkModeContainerValues))
 	authsignalDarkMode.PageBackground = authsignal.SetValue(buildAuthsignalPageBackgroundCreateObject(darkModePageBackgroundValues))
 
 	if len(darkModeValues.LogoUrl.ValueString()) > 0 {
@@ -624,6 +654,48 @@ func buildAuthsignalContainerUpdateObject(container containerModel) authsignal.C
 		authsignalContainer.LogoHeight = authsignal.SetNull(container.LogoHeight.ValueInt64())
 	}
 
+	// Deliberately without a null branch. An exit position Terraform has not been given belongs to
+	// whoever set it in the Portal, and a null would clear it on every apply.
+	if len(container.ExitPosition.ValueString()) > 0 {
+		authsignalContainer.ExitPosition = authsignal.SetValue(container.ExitPosition.ValueString())
+	}
+
+	return authsignalContainer
+}
+
+func buildAuthsignalModeContainerUpdateObject(container modeContainerModel) authsignal.ModeContainer {
+	var authsignalContainer authsignal.ModeContainer
+
+	if len(container.ContentAlignment.ValueString()) > 0 {
+		authsignalContainer.ContentAlignment = authsignal.SetValue(container.ContentAlignment.ValueString())
+	} else {
+		authsignalContainer.ContentAlignment = authsignal.SetNull(container.ContentAlignment.ValueString())
+	}
+
+	if container.Padding.ValueInt64() != 0 {
+		authsignalContainer.Padding = authsignal.SetValue(container.Padding.ValueInt64())
+	} else {
+		authsignalContainer.Padding = authsignal.SetNull(container.Padding.ValueInt64())
+	}
+
+	if len(container.LogoAlignment.ValueString()) > 0 {
+		authsignalContainer.LogoAlignment = authsignal.SetValue(container.LogoAlignment.ValueString())
+	} else {
+		authsignalContainer.LogoAlignment = authsignal.SetNull(container.LogoAlignment.ValueString())
+	}
+
+	if len(container.LogoPosition.ValueString()) > 0 {
+		authsignalContainer.LogoPosition = authsignal.SetValue(container.LogoPosition.ValueString())
+	} else {
+		authsignalContainer.LogoPosition = authsignal.SetNull(container.LogoPosition.ValueString())
+	}
+
+	if container.LogoHeight.ValueInt64() != 0 {
+		authsignalContainer.LogoHeight = authsignal.SetValue(container.LogoHeight.ValueInt64())
+	} else {
+		authsignalContainer.LogoHeight = authsignal.SetNull(container.LogoHeight.ValueInt64())
+	}
+
 	return authsignalContainer
 }
 
@@ -697,7 +769,7 @@ func buildAuthsignalThemeUpdateObject(ctx context.Context, resp *resource.Update
 	var darkModeValues darkModeModel
 	var darkModeColorsValues colorsModel
 	var darkModeBordersValues bordersModel
-	var darkModeContainerValues containerModel
+	var darkModeContainerValues modeContainerModel
 	var darkModePageBackgroundValues pageBackgroundModel
 
 	if !input.DarkMode.IsNull() {
@@ -771,7 +843,7 @@ func buildAuthsignalThemeUpdateObject(ctx context.Context, resp *resource.Update
 	var authsignalDarkMode authsignal.DarkMode
 	authsignalDarkMode.Colors = authsignal.SetValue(buildAuthsignalColorsUpdateObject(darkModeColorsValues))
 	authsignalDarkMode.Borders = authsignal.SetValue(buildAuthsignalBordersUpdateObject(darkModeBordersValues))
-	authsignalDarkMode.Container = authsignal.SetValue(buildAuthsignalContainerUpdateObject(darkModeContainerValues))
+	authsignalDarkMode.Container = authsignal.SetValue(buildAuthsignalModeContainerUpdateObject(darkModeContainerValues))
 	authsignalDarkMode.PageBackground = authsignal.SetValue(buildAuthsignalPageBackgroundUpdateObject(darkModePageBackgroundValues))
 
 	if len(darkModeValues.LogoUrl.ValueString()) > 0 {
@@ -906,8 +978,21 @@ func buildAuthsignalShadowsDeleteObject() authsignal.Shadows {
 	return authsignalShadows
 }
 
+// ExitPosition is left out on purpose: Terraform never owned it, so a delete does not clear it.
 func buildAuthsignalContainerDeleteObject(container containerModel) authsignal.Container {
 	var authsignalContainer authsignal.Container
+
+	authsignalContainer.ContentAlignment = authsignal.SetNull(container.ContentAlignment.ValueString())
+	authsignalContainer.Padding = authsignal.SetNull(container.Padding.ValueInt64())
+	authsignalContainer.LogoAlignment = authsignal.SetNull(container.LogoAlignment.ValueString())
+	authsignalContainer.LogoPosition = authsignal.SetNull(container.LogoPosition.ValueString())
+	authsignalContainer.LogoHeight = authsignal.SetNull(container.LogoHeight.ValueInt64())
+
+	return authsignalContainer
+}
+
+func buildAuthsignalModeContainerDeleteObject(container modeContainerModel) authsignal.ModeContainer {
+	var authsignalContainer authsignal.ModeContainer
 
 	authsignalContainer.ContentAlignment = authsignal.SetNull(container.ContentAlignment.ValueString())
 	authsignalContainer.Padding = authsignal.SetNull(container.Padding.ValueInt64())
@@ -945,7 +1030,7 @@ func buildAuthsignalThemeDeleteObject(input themeModel) authsignal.Theme {
 	var darkModeValues darkModeModel
 	var darkModeColorsValues colorsModel
 	var darkModeBordersValues bordersModel
-	var darkModeContainerValues containerModel
+	var darkModeContainerValues modeContainerModel
 	var darkModePageBackgroundValues pageBackgroundModel
 
 	var colorsValues colorsModel
@@ -956,7 +1041,7 @@ func buildAuthsignalThemeDeleteObject(input themeModel) authsignal.Theme {
 	var authsignalDarkMode authsignal.DarkMode
 	authsignalDarkMode.Colors = authsignal.SetValue(buildAuthsignalColorsDeleteObject(darkModeColorsValues))
 	authsignalDarkMode.Borders = authsignal.SetValue(buildAuthsignalBordersDeleteObject(darkModeBordersValues))
-	authsignalDarkMode.Container = authsignal.SetValue(buildAuthsignalContainerDeleteObject(darkModeContainerValues))
+	authsignalDarkMode.Container = authsignal.SetValue(buildAuthsignalModeContainerDeleteObject(darkModeContainerValues))
 	authsignalDarkMode.PageBackground = authsignal.SetValue(buildAuthsignalPageBackgroundDeleteObject(darkModePageBackgroundValues))
 
 	authsignalDarkMode.LogoUrl = authsignal.SetNull(darkModeValues.LogoUrl.ValueString())

--- a/internal/provider/theme_container_plan_modifier.go
+++ b/internal/provider/theme_container_plan_modifier.go
@@ -1,0 +1,51 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// Dropping a block from the configuration clears it on the next apply, which is what Terraform
+// owning the theme means. exit_position is the exception: the Portal's theme editor is where it gets
+// set, so the API keeps it and the plan has to say so, or the apply comes back with a value the plan
+// did not have. Everything else in the container still clears.
+type containerKeepsExitPosition struct{}
+
+func (m containerKeepsExitPosition) Description(_ context.Context) string {
+	return "Keeps a stored exit_position when the configuration has no container block."
+}
+
+func (m containerKeepsExitPosition) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m containerKeepsExitPosition) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	if !req.ConfigValue.IsNull() {
+		return
+	}
+
+	if req.StateValue.IsNull() {
+		resp.PlanValue = types.ObjectNull(containerModel{}.AttributeTypes())
+		return
+	}
+
+	var state containerModel
+	resp.Diagnostics.Append(req.StateValue.As(ctx, &state, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if state.ExitPosition.IsNull() {
+		resp.PlanValue = types.ObjectNull(containerModel{}.AttributeTypes())
+		return
+	}
+
+	kept := containerModel{ExitPosition: state.ExitPosition}
+
+	object, diags := types.ObjectValue(kept.AttributeTypes(), kept.AttributeValues())
+	resp.Diagnostics.Append(diags...)
+	resp.PlanValue = object
+}

--- a/internal/provider/theme_data_source.go
+++ b/internal/provider/theme_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -118,6 +118,10 @@ func (d *themeDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 					},
 					"logo_height": schema.Int64Attribute{
 						Computed: true,
+					},
+					"exit_position": schema.StringAttribute{
+						Description: "Where the exit control sits: in the header band, or below the content. Shared by light and dark mode.",
+						Computed:    true,
 					},
 				},
 				Computed: true,

--- a/internal/provider/theme_exit_position_test.go
+++ b/internal/provider/theme_exit_position_test.go
@@ -1,0 +1,163 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/authsignal/authsignal-management-go/v6"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// Where the exit control sits is theme-wide, so the API rejects it under dark mode.
+func TestTheDarkModeContainerHasNoExitPosition(t *testing.T) {
+	response := &resource.SchemaResponse{}
+	NewThemeResource().(*themeResource).Schema(context.Background(), resource.SchemaRequest{}, response)
+
+	container := response.Schema.Attributes["container"].(schema.SingleNestedAttribute)
+	if _, found := container.Attributes["exit_position"]; !found {
+		t.Fatalf("expected the theme container to take an exit position")
+	}
+
+	darkMode := response.Schema.Attributes["dark_mode"].(schema.SingleNestedAttribute)
+	darkModeContainer := darkMode.Attributes["container"].(schema.SingleNestedAttribute)
+	if _, found := darkModeContainer.Attributes["exit_position"]; found {
+		t.Fatalf("expected the dark mode container to have no exit position")
+	}
+}
+
+// A null clears the stored value, and the theme editor is where an exit position gets set, so an
+// update Terraform was not given one has to leave the key out.
+func TestExitPositionIsOmittedFromAnUpdateUntilItIsSet(t *testing.T) {
+	testCases := []struct {
+		name         string
+		exitPosition types.String
+		expectedJson string
+	}{
+		{
+			name:         "unconfigured",
+			exitPosition: types.StringNull(),
+			expectedJson: "{\"container\":{\"contentAlignment\":null,\"padding\":null,\"logoAlignment\":null,\"logoPosition\":null,\"logoHeight\":null}}",
+		},
+		{
+			name:         "configured",
+			exitPosition: types.StringValue("bottom"),
+			expectedJson: "{\"container\":{\"contentAlignment\":null,\"padding\":null,\"logoAlignment\":null,\"logoPosition\":null,\"logoHeight\":null,\"exitPosition\":\"bottom\"}}",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			theme := authsignal.Theme{
+				Container: authsignal.SetValue(buildAuthsignalContainerUpdateObject(containerModel{ExitPosition: testCase.exitPosition})),
+			}
+
+			jsonBody, err := json.Marshal(theme)
+			if err != nil {
+				t.Fatalf("failed to marshal json: %v", err)
+			}
+
+			if string(jsonBody) != testCase.expectedJson {
+				t.Fatalf("bad json. expected: %v. got : %v", testCase.expectedJson, string(jsonBody))
+			}
+		})
+	}
+}
+
+// Without a container block the plan has to carry the stored exit position, or the apply comes back
+// with a value the plan did not have. The rest of the container still clears.
+func TestAContainerLeavingTheConfigurationKeepsOnlyItsExitPosition(t *testing.T) {
+	attributeTypes := containerModel{}.AttributeTypes()
+
+	testCases := []struct {
+		name                 string
+		state                containerModel
+		stateIsNull          bool
+		expectedNull         bool
+		expectedExitPosition string
+	}{
+		{name: "nothing in state", stateIsNull: true, expectedNull: true},
+		{
+			name:         "state without an exit position",
+			state:        containerModel{Padding: types.Int64Value(61)},
+			expectedNull: true,
+		},
+		{
+			name:                 "state with an exit position",
+			state:                containerModel{Padding: types.Int64Value(61), ExitPosition: types.StringValue("bottom")},
+			expectedExitPosition: "bottom",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			state := types.ObjectNull(attributeTypes)
+			if !testCase.stateIsNull {
+				object, diags := types.ObjectValue(attributeTypes, testCase.state.AttributeValues())
+				if diags.HasError() {
+					t.Fatalf("failed to build the state object: %v", diags)
+				}
+				state = object
+			}
+
+			request := planmodifier.ObjectRequest{
+				ConfigValue: types.ObjectNull(attributeTypes),
+				StateValue:  state,
+				PlanValue:   state,
+			}
+			response := &planmodifier.ObjectResponse{PlanValue: request.PlanValue}
+
+			containerKeepsExitPosition{}.PlanModifyObject(ctx, request, response)
+
+			if response.PlanValue.IsNull() != testCase.expectedNull {
+				t.Fatalf("bad container plan. expected null: %v. got null : %v", testCase.expectedNull, response.PlanValue.IsNull())
+			}
+
+			if testCase.expectedNull {
+				return
+			}
+
+			var planned containerModel
+			if diags := response.PlanValue.As(ctx, &planned, basetypes.ObjectAsOptions{}); diags.HasError() {
+				t.Fatalf("failed to read the planned container: %v", diags)
+			}
+
+			if planned.ExitPosition.ValueString() != testCase.expectedExitPosition {
+				t.Fatalf("bad exit position. expected: %v. got : %v", testCase.expectedExitPosition, planned.ExitPosition.ValueString())
+			}
+
+			if !planned.Padding.IsNull() {
+				t.Fatalf("bad padding. expected: unset. got : %v", planned.Padding.ValueInt64())
+			}
+		})
+	}
+}
+
+// A container block the configuration does set is Terraform's, untouched by the modifier.
+func TestAConfiguredContainerIsPlannedAsWritten(t *testing.T) {
+	attributeTypes := containerModel{}.AttributeTypes()
+
+	configured, diags := types.ObjectValue(attributeTypes, containerModel{Padding: types.Int64Value(61)}.AttributeValues())
+	if diags.HasError() {
+		t.Fatalf("failed to build the config object: %v", diags)
+	}
+
+	request := planmodifier.ObjectRequest{
+		ConfigValue: configured,
+		StateValue:  types.ObjectNull(attributeTypes),
+		PlanValue:   configured,
+	}
+	response := &planmodifier.ObjectResponse{PlanValue: request.PlanValue}
+
+	containerKeepsExitPosition{}.PlanModifyObject(context.Background(), request, response)
+
+	if !response.PlanValue.Equal(configured) {
+		t.Fatalf("bad container plan. expected: %v. got : %v", configured, response.PlanValue)
+	}
+}

--- a/internal/provider/theme_model.go
+++ b/internal/provider/theme_model.go
@@ -1,7 +1,7 @@
 package provider
 
 import (
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -169,7 +169,7 @@ func (m *darkModeModel) CreateObject(input authsignal.DarkModeResponse) types.Ob
 		isNull = 0
 	}
 
-	var container containerModel
+	var container modeContainerModel
 	m.Container = container.CreateObject(input.Container)
 	if !m.Container.IsNull() {
 		isNull = 0
@@ -202,7 +202,7 @@ func (m darkModeModel) AttributeTypes() map[string]attr.Type {
 		"favicon_url":     types.StringType,
 		"primary_color":   types.StringType,
 		"colors":          types.ObjectType{AttrTypes: colorsModel{}.AttributeTypes()},
-		"container":       types.ObjectType{AttrTypes: containerModel{}.AttributeTypes()},
+		"container":       types.ObjectType{AttrTypes: modeContainerModel{}.AttributeTypes()},
 		"borders":         types.ObjectType{AttrTypes: bordersModel{}.AttributeTypes()},
 		"page_background": types.ObjectType{AttrTypes: pageBackgroundModel{}.AttributeTypes()},
 	}
@@ -468,7 +468,95 @@ func (m colorsModel) AttributeValues() map[string]attr.Value {
 }
 
 // CONTAINER
+// ExitPosition sits here and not on modeContainerModel. Where the exit control sits is theme-wide,
+// so the API rejects it under dark_mode.
 type containerModel struct {
+	ContentAlignment types.String `tfsdk:"content_alignment"`
+	Padding          types.Int64  `tfsdk:"padding"`
+	LogoAlignment    types.String `tfsdk:"logo_alignment"`
+	LogoPosition     types.String `tfsdk:"logo_position"`
+	LogoHeight       types.Int64  `tfsdk:"logo_height"`
+	ExitPosition     types.String `tfsdk:"exit_position"`
+}
+
+func (m *containerModel) CreateObject(input authsignal.ContainerResponse) types.Object {
+	isNull := 1
+	if len(input.ContentAlignment) > 0 {
+		isNull = 0
+		m.ContentAlignment = types.StringValue(input.ContentAlignment)
+	} else {
+		m.ContentAlignment = types.StringNull()
+	}
+
+	if input.Padding != 0 {
+		isNull = 0
+		m.Padding = types.Int64Value(input.Padding)
+	} else {
+		m.Padding = types.Int64Null()
+	}
+
+	if len(input.LogoAlignment) > 0 {
+		isNull = 0
+		m.LogoAlignment = types.StringValue(input.LogoAlignment)
+	} else {
+		m.LogoAlignment = types.StringNull()
+	}
+
+	if len(input.LogoPosition) > 0 {
+		isNull = 0
+		m.LogoPosition = types.StringValue(input.LogoPosition)
+	} else {
+		m.LogoPosition = types.StringNull()
+	}
+
+	if input.LogoHeight != 0 {
+		isNull = 0
+		m.LogoHeight = types.Int64Value(input.LogoHeight)
+	} else {
+		m.LogoHeight = types.Int64Null()
+	}
+
+	if len(input.ExitPosition) > 0 {
+		isNull = 0
+		m.ExitPosition = types.StringValue(input.ExitPosition)
+	} else {
+		m.ExitPosition = types.StringNull()
+	}
+
+	if isNull == 1 {
+		return types.ObjectNull(m.AttributeTypes())
+	}
+
+	object, _ := types.ObjectValue(m.AttributeTypes(), m.AttributeValues())
+	return object
+}
+
+func (m containerModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"content_alignment": types.StringType,
+		"padding":           types.Int64Type,
+		"logo_alignment":    types.StringType,
+		"logo_position":     types.StringType,
+		"logo_height":       types.Int64Type,
+		"exit_position":     types.StringType,
+	}
+}
+
+func (m containerModel) AttributeValues() map[string]attr.Value {
+	elements := map[string]attr.Value{}
+	elements["content_alignment"] = m.ContentAlignment
+	elements["padding"] = m.Padding
+	elements["logo_alignment"] = m.LogoAlignment
+	elements["logo_position"] = m.LogoPosition
+	elements["logo_height"] = m.LogoHeight
+	elements["exit_position"] = m.ExitPosition
+	return elements
+}
+
+// MODE CONTAINER
+// The shape a dark mode container takes: every design token the theme container has, less the
+// theme-wide exit position.
+type modeContainerModel struct {
 	ContentAlignment types.String `tfsdk:"content_alignment"`
 	Padding          types.Int64  `tfsdk:"padding"`
 	LogoAlignment    types.String `tfsdk:"logo_alignment"`
@@ -476,7 +564,7 @@ type containerModel struct {
 	LogoHeight       types.Int64  `tfsdk:"logo_height"`
 }
 
-func (m *containerModel) CreateObject(input authsignal.ContainerResponse) types.Object {
+func (m *modeContainerModel) CreateObject(input authsignal.ModeContainerResponse) types.Object {
 	isNull := 1
 	if len(input.ContentAlignment) > 0 {
 		isNull = 0
@@ -521,7 +609,7 @@ func (m *containerModel) CreateObject(input authsignal.ContainerResponse) types.
 	return object
 }
 
-func (m containerModel) AttributeTypes() map[string]attr.Type {
+func (m modeContainerModel) AttributeTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"content_alignment": types.StringType,
 		"padding":           types.Int64Type,
@@ -531,7 +619,7 @@ func (m containerModel) AttributeTypes() map[string]attr.Type {
 	}
 }
 
-func (m containerModel) AttributeValues() map[string]attr.Value {
+func (m modeContainerModel) AttributeValues() map[string]attr.Value {
 	elements := map[string]attr.Value{}
 	elements["content_alignment"] = m.ContentAlignment
 	elements["padding"] = m.Padding

--- a/internal/provider/theme_resource.go
+++ b/internal/provider/theme_resource.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
@@ -145,8 +146,20 @@ func (r *themeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 					"logo_height": schema.Int64Attribute{
 						Optional: true,
 					},
+					"exit_position": schema.StringAttribute{
+						Description: "Where the exit control sits: in the header band, or below the content. Shared by light and dark mode. Leaving it out keeps whatever the theme editor set, so clear it there rather than here. Allowed values: `top`, `bottom`.",
+						Optional:    true,
+						Computed:    true,
+						Validators: []validator.String{
+							stringvalidator.OneOf([]string{"top", "bottom"}...),
+						},
+					},
 				},
 				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Object{
+					containerKeepsExitPosition{},
+				},
 			},
 			"typography": schema.SingleNestedAttribute{
 				Description: "The fonts used in the pre-built UI. A typeface is shared by light and dark mode.",

--- a/internal/provider/theme_resource_test.go
+++ b/internal/provider/theme_resource_test.go
@@ -1,0 +1,29 @@
+package provider
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// The Management API rejects an exit position under dark mode, so the configuration cannot offer
+// one. Terraform turns this away while validating, before the theme is read or written.
+func TestAccThemeRejectsAPerModeExitPosition(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "authsignal_theme" "theme" {
+  name = "Management-API-Testing"
+  dark_mode = {
+    container = {
+      exit_position = "bottom"
+    }
+  }
+}`,
+				ExpectError: regexp.MustCompile("exit_position"),
+			},
+		},
+	})
+}

--- a/internal/provider/theme_switches_test.go
+++ b/internal/provider/theme_switches_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 

--- a/internal/provider/value_list_data_source.go
+++ b/internal/provider/value_list_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"

--- a/internal/provider/value_list_resource.go
+++ b/internal/provider/value_list_resource.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v5"
+	"github.com/authsignal/authsignal-management-go/v6"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"


### PR DESCRIPTION
## Problem

`container.exit_position` moves the pre-built UI's exit affordance out of the header band and below the content. The Management API has accepted it for a while, but practitioners cannot set it until the provider models it.

Where the control sits is theme-wide, so the API rejects an `exitPosition` under `darkMode`.

## Approach

`exit_position` on the theme container, absent from the `dark_mode` container. The models and request builders split along the same line as the SDK's `Container` and `ModeContainer`.

Terraform does not own the value — the theme editor is where it gets set — so an update Terraform was not given one leaves the key out rather than sending a null, which would clear it on every apply.

For that to hold, the plan has to agree with what comes back, or Terraform reports an inconsistent result after apply. Two things make it agree:

- `exit_position` is `Optional` and `Computed`, so a stored value is planned from prior state rather than as null.
- a plan modifier on `container` keeps just that value when the block leaves the configuration, while the rest of the container still clears as it does today.

The trade-off is the usual one for a value an external system owns: removing `exit_position` from the configuration no longer clears it. Clearing happens in the theme editor, which the attribute description says.

## Notes

Requires `authsignal-management-go` v6.0.0 (authsignal/authsignal-management-go#20). `go.sum` resolves once that is tagged, so the license check fails until then — same as the last two SDK bumps.

An acceptance test pins the `dark_mode` rejection so the container types do not get re-merged later. The plan/apply round trip against a live tenant is not covered by a test yet.